### PR TITLE
docs: switch to GitHub Releases distribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,16 @@
-name: Publish to PyPI
+name: Build & Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -16,34 +19,16 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-
       - name: Build package
-        run: python -m build
+        run: |
+          pip install build
+          python -m build
 
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+      - name: Create GitHub Release & Upload
+        uses: softprops/action-gh-release@v2
         with:
-          name: dist
-          path: dist/
-
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/mcp-cn-commerce/
-    permissions:
-      id-token: write
-    steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          files: dist/*
+          generate_release_notes: true
+          make_latest: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -78,14 +78,28 @@ This is the **first open-source MCP server suite for Chinese e-commerce business
 
 ### Installation
 
-```bash
-# Install a specific platform server
-pip install mcp-cn-commerce[oceanengine]   # 巨量引擎 advertising
-pip install mcp-cn-commerce[doudian]        # 抖店 Douyin Shop
-pip install mcp-cn-commerce[jd]              # 京东 JD.com
+#### From GitHub Releases (recommended — no registration needed)
 
-# Or install all Phase 1 servers at once
-pip install mcp-cn-commerce[all]
+```bash
+# Visit the latest Release and download the .whl file
+# https://github.com/TonyWang-hub/mcp-cn-commerce/releases/latest
+
+# Or install directly from the Release URL:
+pip install https://github.com/TonyWang-hub/mcp-cn-commerce/releases/latest/download/mcp_cn_commerce-0.1.0-py3-none-any.whl
+```
+
+#### From Git (always latest)
+
+```bash
+pip install git+https://github.com/TonyWang-hub/mcp-cn-commerce.git
+```
+
+#### For development
+
+```bash
+git clone https://github.com/TonyWang-hub/mcp-cn-commerce.git
+cd mcp-cn-commerce
+pip install -e ".[dev]"
 ```
 
 ### Configuration

--- a/README_zh.md
+++ b/README_zh.md
@@ -85,14 +85,28 @@
 
 ### 安装
 
-```bash
-# 安装单个平台
-pip install mcp-cn-commerce[oceanengine]   # 巨量引擎广告
-pip install mcp-cn-commerce[doudian]        # 抖店
-pip install mcp-cn-commerce[jd]              # 京东
+#### 从 GitHub Releases 下载（推荐 — 无需注册）
 
-# 或安装所有 Phase 1 平台
-pip install mcp-cn-commerce[all]
+```bash
+# 下载最新 Release 的 .whl 文件安装
+# https://github.com/TonyWang-hub/mcp-cn-commerce/releases/latest
+
+# 或直接安装：
+pip install https://github.com/TonyWang-hub/mcp-cn-commerce/releases/latest/download/mcp_cn_commerce-0.1.0-py3-none-any.whl
+```
+
+#### 从 Git 安装（始终最新）
+
+```bash
+pip install git+https://github.com/TonyWang-hub/mcp-cn-commerce.git
+```
+
+#### 开发模式
+
+```bash
+git clone https://github.com/TonyWang-hub/mcp-cn-commerce.git
+cd mcp-cn-commerce
+pip install -e ".[dev]"
 ```
 
 ### 配置凭证


### PR DESCRIPTION
## Changes

- Remove PyPI dependency — no registration, no token, no 2FA
- Publish workflow now builds  and attaches to GitHub Releases  
- README install instructions updated: install from GitHub Releases URL or git
- Users just run: `pip install https://github.com/.../releases/latest/download/...whl`

## How to release


That's it. No PyPI account needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)