### PR TITLE
fix: hmac.new → hmac.HMAC 修复签名算法调用

### DIFF
--- a/shared/cn_commerce_base.py
+++ b/shared/cn_commerce_base.py
@@ -85,7 +85,7 @@ class CommerceMCPBase:
         if self.sign_method == SignMethod.MD5:
             return hashlib.md5(raw.encode()).hexdigest().upper()
         elif self.sign_method == SignMethod.HMAC_SHA256:
-            return hmac.new(self.app_secret.encode(), raw.encode(), hashlib.sha256).hexdigest().upper()
+            return hmac.HMAC(self.app_secret.encode(), raw.encode(), hashlib.sha256).hexdigest().upper()
         raise ValueError(f"Unknown sign method: {self.sign_method}")
 
     # ── Pagination ────────────────────────────────────────


### PR DESCRIPTION
## 问题
 使用了 （错误的 API），应该用 。

## 影响
- 所有使用 HMAC_SHA256 签名的平台（如京东、淘宝）
- 签名验证会失败

## 修复
-  → 

## 测试
- [ ] 本地测试通过
- [ ] CI 测试通过