### PR TITLE
feat: 添加所有 8 个平台的 optional-dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,21 @@ urls = {Repository = "https://github.com/TonyWang-hub/mcp-cn-commerce", Issues =
 oceanengine = ["mcp-cn-oceanengine"]
 doudian = ["mcp-cn-doudian"]
 jd = ["mcp-cn-jd"]
-all = ["mcp-cn-oceanengine", "mcp-cn-doudian", "mcp-cn-jd"]
+taobao = ["mcp-cn-taobao"]
+pinduoduo = ["mcp-cn-pinduoduo"]
+kuaishou = ["mcp-cn-kuaishou"]
+xiaohongshu = ["mcp-cn-xiaohongshu"]
+weixin-store = ["mcp-cn-weixin-store"]
+all = [
+    "mcp-cn-oceanengine",
+    "mcp-cn-doudian",
+    "mcp-cn-jd",
+    "mcp-cn-taobao",
+    "mcp-cn-pinduoduo",
+    "mcp-cn-kuaishou",
+    "mcp-cn-xiaohongshu",
+    "mcp-cn-weixin-store",
+]
 dev = ["pytest>=7.0", "pytest-asyncio"]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## 变更
- 新增 taobao、pinduoduo、kuaishou、xiaohongshu、weixin-store 的依赖声明
- all 依赖更新为包含所有 8 个平台

## 用法
```bash
pip install mcp-cn-commerce[taobao]     # 只装淘宝
pip install mcp-cn-commerce[all]         # 装所有平台
```