### PR TITLE
docs: 修正 Citation 年份 2025 → 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If you use mcp-cn-commerce in your research or project:
 @software{mcp-cn-commerce,
   author = {Wang, Zhuo},
   title = {mcp-cn-commerce: MCP Servers for Chinese E-Commerce Platforms},
-  year = {2025},
+  year = {2026},
   url = {https://github.com/TonyWang-hub/mcp-cn-commerce}
 }
 ```


### PR DESCRIPTION
## 变更
- Citation 年份从 2025 修正为 2026