### PR TITLE
feat: 添加 Makefile 统一开发命令

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: help install test lint format clean
+
+# Default target
+help:
+	@echo "mcp-cn-commerce Development Commands"
+	@echo "====================================="
+	@echo ""
+	@echo "  make install    - Install all dependencies (dev + all platforms)"
+	@echo "  make test       - Run all tests"
+	@echo "  make lint       - Check code style (black + ruff)"
+	@echo "  make format     - Auto-format code (black + ruff)"
+	@echo "  make clean      - Remove cache files"
+	@echo ""
+
+# Install dependencies
+install:
+	pip install -e ".[dev]"
+	pip install -e servers/oceanengine/
+	pip install -e servers/doudian/
+	pip install -e servers/jd/
+	pip install -e servers/taobao/
+	pip install -e servers/pinduoduo/
+	pip install -e servers/kuaishou/
+	pip install -e servers/xiaohongshu/
+	pip install -e servers/weixin-store/
+
+# Run tests
+test:
+	PYTHONPATH=servers/oceanengine/src:servers/doudian/src:servers/jd/src:servers/taobao/src:servers/pinduoduo/src:servers/kuaishou/src:servers/xiaohongshu/src:servers/weixin-store/src \
+	pytest servers/ -v --tb=short
+
+# Run tests with coverage
+test-cov:
+	PYTHONPATH=servers/oceanengine/src:servers/doudian/src:servers/jd/src:servers/taobao/src:servers/pinduoduo/src:servers/kuaishou/src:servers/xiaohongshu/src:servers/weixin-store/src \
+	pytest servers/ -v --tb=short --cov=servers --cov-report=html --cov-report=term
+
+# Lint code
+lint:
+	black --check .
+	ruff check .
+
+# Format code
+format:
+	black .
+	ruff check --fix .
+
+# Clean cache files
+clean:
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
+	rm -rf .coverage htmlcov/ .mypy_cache/


### PR DESCRIPTION
## 变更
添加 Makefile 统一开发命令入口

## 命令
- `make install` - 安装所有依赖
- `make test` - 运行测试
- `make test-cov` - 运行测试 + 覆盖率报告
- `make lint` - 代码检查 (black + ruff)
- `make format` - 自动格式化
- `make clean` - 清理缓存文件

## 用途
简化本地开发流程，避免记忆复杂的 PYTHONPATH 设置。