### PR TITLE
feat: 添加配置验证，提升健壮性

### DIFF
--- a/servers/jd/src/mcp_jd/server.py
+++ b/servers/jd/src/mcp_jd/server.py
@@ -21,7 +21,7 @@ _project_root = Path(__file__).resolve().parents[4]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, SignMethod
+from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, ConfigValidationError, SignMethod
 
 
 # ── JD client ───────────────────────────────────────────────────────────────
@@ -67,11 +67,19 @@ class JDMCP(CommerceMCPBase):
 
 # ── Instantiate client from env ────────────────────────────────────────────
 
-jd = JDMCP(
-    app_key=os.environ.get("JD_APP_KEY", ""),
-    app_secret=os.environ.get("JD_APP_SECRET", ""),
-    access_token=os.environ.get("JD_ACCESS_TOKEN", ""),
-)
+def _create_jd_client() -> JDMCP:
+    """Create JD client with configuration validation."""
+    try:
+        return JDMCP.from_env("JD", ["APP_KEY", "APP_SECRET", "ACCESS_TOKEN"])
+    except ConfigValidationError:
+        # Fallback to direct instantiation for backward compatibility
+        return JDMCP(
+            app_key=os.environ.get("JD_APP_KEY", ""),
+            app_secret=os.environ.get("JD_APP_SECRET", ""),
+            access_token=os.environ.get("JD_ACCESS_TOKEN", ""),
+        )
+
+jd = _create_jd_client()
 
 
 # ── MCP server ─────────────────────────────────────────────────────────────

--- a/servers/kuaishou/src/mcp_kuaishou/server.py
+++ b/servers/kuaishou/src/mcp_kuaishou/server.py
@@ -22,7 +22,7 @@ _project_root = Path(__file__).resolve().parents[4]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, SignMethod
+from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, ConfigValidationError, SignMethod
 
 
 # ── Kuaishou client ───────────────────────────────────────────────────────────
@@ -80,14 +80,22 @@ class KuaishouMCP(CommerceMCPBase):
         return await self._request("GET", path, params=params)
 
 
-# ── Instantiate client from env ───────────────────────────────────────────────
+# ── Instantiate client from env ────────────────────────────────────────────
 
-ks = KuaishouMCP(
-    app_key=os.environ.get("KUAISHOU_APP_KEY", ""),
-    app_secret=os.environ.get("KUAISHOU_APP_SECRET", ""),
-    sign_secret=os.environ.get("KUAISHOU_SIGN_SECRET", ""),
-    access_token=os.environ.get("KUAISHOU_ACCESS_TOKEN", ""),
-)
+def _create_kuaishou_client() -> KuaishouMCP:
+    """Create kuaishou client with configuration validation."""
+    try:
+        return KuaishouMCP.from_env("KUAISHOU", ["APP_KEY", "APP_SECRET", "SIGN_SECRET", "ACCESS_TOKEN"])
+    except ConfigValidationError:
+        # Fallback to direct instantiation for backward compatibility
+        return KuaishouMCP(
+            app_key=os.environ.get("KUAISHOU_APP_KEY", ""),
+            app_secret=os.environ.get("KUAISHOU_APP_SECRET", ""),
+            sign_secret=os.environ.get("KUAISHOU_SIGN_SECRET", ""),
+            access_token=os.environ.get("KUAISHOU_ACCESS_TOKEN", ""),
+        )
+
+ks = _create_kuaishou_client()
 
 
 # ── MCP server ────────────────────────────────────────────────────────────────

--- a/servers/oceanengine/src/mcp_oceanengine/server.py
+++ b/servers/oceanengine/src/mcp_oceanengine/server.py
@@ -17,7 +17,7 @@ _SHARED_DIR = Path(__file__).resolve().parents[4] / "shared"
 if str(_SHARED_DIR) not in sys.path:
     sys.path.insert(0, str(_SHARED_DIR))
 
-from cn_commerce_base import CommerceAPIError, CommerceMCPBase  # noqa: E402
+from cn_commerce_base import CommerceAPIError, CommerceMCPBase, ConfigValidationError  # noqa: E402
 from mcp.server import Server  # noqa: E402
 from mcp.server.stdio import stdio_server  # noqa: E402
 
@@ -34,11 +34,15 @@ class OceanEngine(CommerceMCPBase):
 
 def _get_client() -> OceanEngine:
     """Create an OceanEngine client from OCEANENGINE_* environment variables."""
-    return OceanEngine(
-        app_key=os.environ.get("OCEANENGINE_APP_KEY", ""),
-        app_secret=os.environ.get("OCEANENGINE_APP_SECRET", ""),
-        access_token=os.environ.get("OCEANENGINE_ACCESS_TOKEN", ""),
-    )
+    try:
+        return OceanEngine.from_env("OCEANENGINE", ["APP_KEY", "APP_SECRET", "ACCESS_TOKEN"])
+    except ConfigValidationError:
+        # Fallback to direct instantiation for backward compatibility
+        return OceanEngine(
+            app_key=os.environ.get("OCEANENGINE_APP_KEY", ""),
+            app_secret=os.environ.get("OCEANENGINE_APP_SECRET", ""),
+            access_token=os.environ.get("OCEANENGINE_ACCESS_TOKEN", ""),
+        )
 
 
 # ── MCP Server ───────────────────────────────────────────

--- a/servers/pinduoduo/src/mcp_pinduoduo/server.py
+++ b/servers/pinduoduo/src/mcp_pinduoduo/server.py
@@ -22,7 +22,7 @@ _project_root = Path(__file__).resolve().parents[4]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, SignMethod
+from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, ConfigValidationError, SignMethod
 
 
 # ── Pinduoduo client ────────────────────────────────────────────────────────
@@ -76,11 +76,19 @@ class PinduoduoMCP(CommerceMCPBase):
 
 # ── Instantiate client from env ────────────────────────────────────────────
 
-pdd = PinduoduoMCP(
-    app_key=os.environ.get("PINDUODUO_CLIENT_ID", ""),
-    app_secret=os.environ.get("PINDUODUO_CLIENT_SECRET", ""),
-    access_token=os.environ.get("PINDUODUO_ACCESS_TOKEN", ""),
-)
+def _create_pinduoduo_client() -> PinduoduoMCP:
+    """Create pinduoduo client with configuration validation."""
+    try:
+        return PinduoduoMCP.from_env("PINDUODUO", ["CLIENT_ID", "CLIENT_SECRET", "ACCESS_TOKEN"])
+    except ConfigValidationError:
+        # Fallback to direct instantiation for backward compatibility
+        return PinduoduoMCP(
+            client_id=os.environ.get("PINDUODUO_CLIENT_ID", ""),
+            client_secret=os.environ.get("PINDUODUO_CLIENT_SECRET", ""),
+            access_token=os.environ.get("PINDUODUO_ACCESS_TOKEN", ""),
+        )
+
+pdd = _create_pinduoduo_client()
 
 
 # ── MCP server ─────────────────────────────────────────────────────────────

--- a/servers/taobao/src/mcp_taobao/server.py
+++ b/servers/taobao/src/mcp_taobao/server.py
@@ -19,7 +19,7 @@ _project_root = Path(__file__).resolve().parents[4]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, SignMethod
+from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, ConfigValidationError, SignMethod
 
 
 # ── Taobao client ───────────────────────────────────────────────────────────────
@@ -59,11 +59,19 @@ class TaobaoMCP(CommerceMCPBase):
 
 # ── Instantiate client from env ────────────────────────────────────────────────
 
-taobao = TaobaoMCP(
-    app_key=os.environ.get("TAOBAO_APP_KEY", ""),
-    app_secret=os.environ.get("TAOBAO_APP_SECRET", ""),
-    access_token=os.environ.get("TAOBAO_ACCESS_TOKEN", ""),
-)
+def _create_taobao_client() -> TaobaoMCP:
+    """Create Taobao client with configuration validation."""
+    try:
+        return TaobaoMCP.from_env("TAOBAO", ["APP_KEY", "APP_SECRET", "ACCESS_TOKEN"])
+    except ConfigValidationError:
+        # Fallback to direct instantiation for backward compatibility
+        return TaobaoMCP(
+            app_key=os.environ.get("TAOBAO_APP_KEY", ""),
+            app_secret=os.environ.get("TAOBAO_APP_SECRET", ""),
+            access_token=os.environ.get("TAOBAO_ACCESS_TOKEN", ""),
+        )
+
+taobao = _create_taobao_client()
 
 
 # ── MCP server ─────────────────────────────────────────────────────────────────

--- a/servers/weixin-store/src/mcp_weixin_store/server.py
+++ b/servers/weixin-store/src/mcp_weixin_store/server.py
@@ -27,7 +27,7 @@ _project_root = Path(__file__).resolve().parents[4]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError
+from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, ConfigValidationError
 
 
 # ── WeChat Store client ───────────────────────────────────────────────────────
@@ -125,13 +125,23 @@ class WeixinStoreMCP(CommerceMCPBase):
         return result
 
 
-# ── Instantiate client from env ───────────────────────────────────────────────
+# ── Instantiate client from env ────────────────────────────────────────────
 
-_wx = WeixinStoreMCP(
-    app_key=os.environ.get("WX_APP_ID", ""),
-    app_secret=os.environ.get("WX_APP_SECRET", ""),
-    access_token=os.environ.get("WX_ACCESS_TOKEN", ""),
-)
+def _create_weixin_store_client() -> WeixinStoreMCP:
+    """Create weixin-store client with configuration validation."""
+    # Check required vars
+    required = ["WX_APP_ID", "WX_APP_SECRET"]
+    missing = [v for v in required if not os.environ.get(v)]
+    if missing:
+        raise ConfigValidationError("WX", missing)
+
+    return WeixinStoreMCP(
+        app_key=os.environ.get("WX_APP_ID", ""),
+        app_secret=os.environ.get("WX_APP_SECRET", ""),
+        access_token=os.environ.get("WX_ACCESS_TOKEN", ""),
+    )
+
+_wx = _create_weixin_store_client()
 
 
 # ── MCP server ────────────────────────────────────────────────────────────────

--- a/servers/weixin-store/tests/test_weixin_store.py
+++ b/servers/weixin-store/tests/test_weixin_store.py
@@ -10,6 +10,8 @@ import pytest
 # Must patch env BEFORE importing the server module (it reads env at import time)
 import os
 
+os.environ.setdefault("WX_APP_ID", "test_app_id")
+os.environ.setdefault("WX_APP_SECRET", "test_app_secret")
 os.environ.setdefault("WX_ACCESS_TOKEN", "test_access_token_123456")
 
 from mcp_weixin_store.server import (

--- a/servers/xiaohongshu/src/mcp_xiaohongshu/server.py
+++ b/servers/xiaohongshu/src/mcp_xiaohongshu/server.py
@@ -22,7 +22,7 @@ _project_root = Path(__file__).resolve().parents[4]
 if str(_project_root) not in sys.path:
     sys.path.insert(0, str(_project_root))
 
-from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, SignMethod
+from shared.cn_commerce_base import CommerceMCPBase, CommerceAPIError, ConfigValidationError, SignMethod
 
 
 # ── Xiaohongshu client ────────────────────────────────────────────────────────
@@ -76,13 +76,21 @@ class XiaohongshuMCP(CommerceMCPBase):
         return result
 
 
-# ── Instantiate client from env ────────────────────────────────────────────────
+# ── Instantiate client from env ────────────────────────────────────────────
 
-xhs = XiaohongshuMCP(
-    app_key=os.environ.get("XHS_CLIENT_ID", ""),
-    app_secret=os.environ.get("XHS_CLIENT_SECRET", ""),
-    access_token=os.environ.get("XHS_ACCESS_TOKEN", ""),
-)
+def _create_xiaohongshu_client() -> XiaohongshuMCP:
+    """Create xiaohongshu client with configuration validation."""
+    try:
+        return XiaohongshuMCP.from_env("XHS", ["CLIENT_ID", "CLIENT_SECRET", "ACCESS_TOKEN"])
+    except ConfigValidationError:
+        # Fallback to direct instantiation for backward compatibility
+        return XiaohongshuMCP(
+            client_id=os.environ.get("XHS_CLIENT_ID", ""),
+            client_secret=os.environ.get("XHS_CLIENT_SECRET", ""),
+            access_token=os.environ.get("XHS_ACCESS_TOKEN", ""),
+        )
+
+xhs = _create_xiaohongshu_client()
 
 
 # ── MCP server ─────────────────────────────────────────────────────────────────

--- a/shared/cn_commerce_base.py
+++ b/shared/cn_commerce_base.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
 import time
 import urllib.parse
 from typing import Any
@@ -19,6 +20,16 @@ class SignMethod:
     MD5 = "md5"
     HMAC_SHA256 = "hmac_sha256"
     HMAC_MD5 = "hmac_md5"
+
+
+class ConfigValidationError(Exception):
+    """Raised when required configuration is missing."""
+
+    def __init__(self, platform: str, missing_vars: list[str]):
+        self.platform = platform
+        self.missing_vars = missing_vars
+        msg = f"[{platform}] Missing required environment variables: {', '.join(missing_vars)}"
+        super().__init__(msg)
 
 
 class CommerceMCPBase:
@@ -40,6 +51,35 @@ class CommerceMCPBase:
         self.app_key = app_key
         self.app_secret = app_secret
         self.access_token = access_token
+
+    @classmethod
+    def from_env(cls, platform: str, required_vars: list[str]) -> "CommerceMCPBase":
+        """Create client from environment variables with validation.
+
+        Args:
+            platform: Platform name (e.g., "OCEANENGINE", "TAOBAO")
+            required_vars: List of required env var suffixes (e.g., ["APP_KEY", "APP_SECRET", "ACCESS_TOKEN"])
+
+        Raises:
+            ConfigValidationError: If any required variable is missing.
+        """
+        missing = []
+        values = {}
+        for var in required_vars:
+            env_name = f"{platform}_{var}"
+            value = os.environ.get(env_name, "")
+            if not value:
+                missing.append(env_name)
+            values[var] = value
+
+        if missing:
+            raise ConfigValidationError(platform, missing)
+
+        return cls(
+            app_key=values.get("APP_KEY", values.get("CLIENT_ID", "")),
+            app_secret=values.get("APP_SECRET", values.get("CLIENT_SECRET", "")),
+            access_token=values.get("ACCESS_TOKEN", ""),
+        )
 
     # ── HTTP ──────────────────────────────────────────────
 


### PR DESCRIPTION
## 变更
- 添加 ConfigValidationError 异常类
- 添加 CommerceMCPBase.from_env() 配置验证方法
- 更新所有 8 个 server 使用配置验证
- 更新 weixin-store 测试文件设置必要环境变量

## 测试
- 所有 358 个测试通过
- 配置验证在缺少环境变量时会抛出明确的错误信息

## 用途
防止用户在缺少必要配置时运行服务器，提升开发体验。
