### PR TITLE
test: 添加 shared 基类单元测试，提升测试覆盖率

### DIFF
--- a/tests/test_cn_commerce_base.py
+++ b/tests/test_cn_commerce_base.py
@@ -9,7 +9,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -26,7 +26,6 @@ from cn_commerce_base import (
     SignMethod,
     format_error_response,
 )
-
 
 # ── SignMethod Tests ──────────────────────────────────────
 

--- a/tests/test_cn_commerce_base.py
+++ b/tests/test_cn_commerce_base.py
@@ -1,0 +1,280 @@
+"""Tests for the shared cn_commerce_base module.
+
+Tests the base classes, error handling, and utility functions.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Add the shared directory to the path
+_shared_dir = Path(__file__).resolve().parents[1] / "shared"
+if str(_shared_dir) not in sys.path:
+    sys.path.insert(0, str(_shared_dir))
+
+from cn_commerce_base import (
+    CommerceAPIError,
+    CommerceMCPBase,
+    ConfigValidationError,
+    RateLimiter,
+    SignMethod,
+    format_error_response,
+)
+
+
+# ── SignMethod Tests ──────────────────────────────────────
+
+
+class TestSignMethod:
+    """Tests for SignMethod constants."""
+
+    def test_md5_constant(self):
+        assert SignMethod.MD5 == "md5"
+
+    def test_hmac_sha256_constant(self):
+        assert SignMethod.HMAC_SHA256 == "hmac_sha256"
+
+    def test_hmac_md5_constant(self):
+        assert SignMethod.HMAC_MD5 == "hmac_md5"
+
+
+# ── ConfigValidationError Tests ───────────────────────────
+
+
+class TestConfigValidationError:
+    """Tests for ConfigValidationError."""
+
+    def test_single_missing_var(self):
+        err = ConfigValidationError("TEST", ["APP_KEY"])
+        assert err.platform == "TEST"
+        assert err.missing_vars == ["APP_KEY"]
+        assert "APP_KEY" in str(err)
+
+    def test_multiple_missing_vars(self):
+        err = ConfigValidationError("TEST", ["APP_KEY", "APP_SECRET"])
+        assert err.platform == "TEST"
+        assert err.missing_vars == ["APP_KEY", "APP_SECRET"]
+        assert "APP_KEY" in str(err)
+        assert "APP_SECRET" in str(err)
+
+    def test_is_exception(self):
+        err = ConfigValidationError("TEST", ["VAR"])
+        assert isinstance(err, Exception)
+
+
+# ── CommerceAPIError Tests ────────────────────────────────
+
+
+class TestCommerceAPIError:
+    """Tests for CommerceAPIError."""
+
+    def test_error_attributes(self):
+        err = CommerceAPIError(40001, "Invalid parameters")
+        assert err.code == 40001
+        assert err.msg == "Invalid parameters"
+
+    def test_error_message_format(self):
+        err = CommerceAPIError(40001, "Invalid parameters")
+        assert "[40001] Invalid parameters" in str(err)
+
+    def test_is_exception(self):
+        err = CommerceAPIError(1, "test")
+        assert isinstance(err, Exception)
+
+
+# ── RateLimiter Tests ─────────────────────────────────────
+
+
+class TestRateLimiter:
+    """Tests for RateLimiter."""
+
+    def test_default_rate(self):
+        limiter = RateLimiter()
+        assert limiter.requests_per_second == 10.0
+
+    def test_custom_rate(self):
+        limiter = RateLimiter(requests_per_second=5.0)
+        assert limiter.requests_per_second == 5.0
+
+    def test_min_interval(self):
+        limiter = RateLimiter(requests_per_second=10.0)
+        assert limiter.min_interval == 0.1
+
+    @pytest.mark.asyncio
+    async def test_acquire_first_call(self):
+        limiter = RateLimiter()
+        # First call should not wait
+        await limiter.acquire()
+        assert limiter.last_request_time > 0
+
+    @pytest.mark.asyncio
+    async def test_acquire_respects_rate_limit(self):
+        limiter = RateLimiter(requests_per_second=100.0)
+        # First call
+        await limiter.acquire()
+        # Second call should wait
+        await limiter.acquire()
+        # Both calls should complete without error
+
+
+# ── format_error_response Tests ───────────────────────────
+
+
+class TestFormatErrorResponse:
+    """Tests for format_error_response."""
+
+    def test_commerce_api_error(self):
+        err = CommerceAPIError(40001, "Invalid parameters")
+        result = json.loads(format_error_response(err))
+        assert result["error"]["code"] == 40001
+        assert result["error"]["message"] == "Invalid parameters"
+
+    def test_generic_exception(self):
+        err = ValueError("Something went wrong")
+        result = json.loads(format_error_response(err))
+        assert result["error"]["message"] == "Something went wrong"
+
+    def test_returns_valid_json(self):
+        err = CommerceAPIError(1, "test")
+        result = format_error_response(err)
+        # Should not raise
+        json.loads(result)
+
+
+# ── CommerceMCPBase Tests ─────────────────────────────────
+
+
+class TestCommerceMCPBase:
+    """Tests for CommerceMCPBase."""
+
+    def test_init_default_values(self):
+        client = CommerceMCPBase()
+        assert client.app_key == ""
+        assert client.app_secret == ""
+        assert client.access_token == ""
+
+    def test_init_with_values(self):
+        client = CommerceMCPBase(
+            app_key="test_key",
+            app_secret="test_secret",
+            access_token="test_token",
+        )
+        assert client.app_key == "test_key"
+        assert client.app_secret == "test_secret"
+        assert client.access_token == "test_token"
+
+    def test_has_rate_limiter(self):
+        client = CommerceMCPBase()
+        assert client.rate_limiter is not None
+        assert isinstance(client.rate_limiter, RateLimiter)
+
+    def test_from_env_success(self):
+        with patch.dict(
+            os.environ,
+            {
+                "TEST_APP_KEY": "key",
+                "TEST_APP_SECRET": "secret",
+                "TEST_ACCESS_TOKEN": "token",
+            },
+        ):
+            client = CommerceMCPBase.from_env("TEST", ["APP_KEY", "APP_SECRET", "ACCESS_TOKEN"])
+            assert client.app_key == "key"
+            assert client.app_secret == "secret"
+            assert client.access_token == "token"
+
+    def test_from_env_missing_vars(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ConfigValidationError) as exc_info:
+                CommerceMCPBase.from_env("TEST", ["APP_KEY", "APP_SECRET"])
+            assert "TEST" in str(exc_info.value)
+            assert "TEST_APP_KEY" in str(exc_info.value)
+            assert "TEST_APP_SECRET" in str(exc_info.value)
+
+    def test_from_env_partial_vars(self):
+        with patch.dict(os.environ, {"TEST_APP_KEY": "key"}, clear=True):
+            with pytest.raises(ConfigValidationError):
+                CommerceMCPBase.from_env("TEST", ["APP_KEY", "APP_SECRET"])
+
+    def test_sign_md5(self):
+        client = CommerceMCPBase(app_secret="test_secret")
+        client.sign_method = SignMethod.MD5
+        params = {"app_key": "test", "timestamp": "1234567890"}
+        result = client._sign(params)
+        assert isinstance(result, str)
+        assert len(result) == 32  # MD5 hex length
+
+    def test_sign_hmac_sha256(self):
+        client = CommerceMCPBase(app_secret="test_secret")
+        client.sign_method = SignMethod.HMAC_SHA256
+        params = {"app_key": "test", "timestamp": "1234567890"}
+        result = client._sign(params)
+        assert isinstance(result, str)
+        assert len(result) == 64  # SHA256 hex length
+
+    def test_sign_excludes_sign_params(self):
+        client = CommerceMCPBase(app_secret="test_secret")
+        client.sign_method = SignMethod.MD5
+        params = {
+            "app_key": "test",
+            "timestamp": "1234567890",
+            "sign": "should_be_excluded",
+            "sign_method": "should_be_excluded",
+        }
+        result = client._sign(params)
+        assert isinstance(result, str)
+
+    def test_sign_empty_values_excluded(self):
+        client = CommerceMCPBase(app_secret="test_secret")
+        client.sign_method = SignMethod.MD5
+        params = {"app_key": "test", "empty_param": ""}
+        result = client._sign(params)
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_paginate_single_page(self):
+        client = CommerceMCPBase()
+        mock_fetch = AsyncMock(return_value={"result": [{"id": 1}, {"id": 2}]})
+        result = await client._paginate(mock_fetch, page_size=10)
+        assert len(result) == 2
+        mock_fetch.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_paginate_multiple_pages(self):
+        client = CommerceMCPBase()
+        mock_fetch = AsyncMock(
+            side_effect=[
+                {"result": [{"id": 1}, {"id": 2}]},
+                {"result": [{"id": 3}]},
+            ]
+        )
+        result = await client._paginate(mock_fetch, page_size=2)
+        assert len(result) == 3
+        assert mock_fetch.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_paginate_empty_result(self):
+        client = CommerceMCPBase()
+        mock_fetch = AsyncMock(return_value={"result": []})
+        result = await client._paginate(mock_fetch)
+        assert len(result) == 0
+
+    @pytest.mark.asyncio
+    async def test_paginate_uses_list_key(self):
+        client = CommerceMCPBase()
+        mock_fetch = AsyncMock(return_value={"list": [{"id": 1}]})
+        result = await client._paginate(mock_fetch)
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_paginate_max_pages(self):
+        client = CommerceMCPBase()
+        mock_fetch = AsyncMock(return_value={"result": [{"id": 1}]})
+        result = await client._paginate(mock_fetch, page_size=1, max_pages=3)
+        assert len(result) == 3
+        assert mock_fetch.call_count == 3


### PR DESCRIPTION
## 变更
- 添加 tests/test_cn_commerce_base.py 测试文件
- 测试 SignMethod、ConfigValidationError、CommerceAPIError
- 测试 RateLimiter、format_error_response
- 测试 CommerceMCPBase 初始化、from_env、_sign、_paginate

## 测试结果
- 所有 390 个测试通过（原有 358 + 新增 32）

## 用途
提升 shared 基类的测试覆盖率，确保核心功能的正确性。
