### PR TITLE
feat: add request encryption and audit logging

### DIFF
--- a/docs/request-encryption.md
+++ b/docs/request-encryption.md
@@ -1,0 +1,192 @@
+# Request Encryption & Audit
+
+This document describes the request encryption and audit logging features
+added to the `mcp-cn-commerce` shared base.
+
+## Request Encryption
+
+### Supported Algorithms
+
+| Algorithm | Key | Notes |
+|---|---|---|
+| `none` | - | No encryption (default) |
+| `aes_256_cbc` | 64 hex chars (32 bytes) | AES-256 in CBC mode with PKCS7 padding; requires `pyaes` |
+| `xor_cipher` | any hex string | XOR with repeating key; **testing only** |
+
+### Configuration
+
+```python
+from shared.cn_commerce_base import EncryptionConfig, EncryptionMethod
+
+config = EncryptionConfig(
+    method=EncryptionMethod.AES_256_CBC,
+    encryption_key="0123456789abcdef" * 4,  # 32 bytes hex
+    include_encrypted_header=True,           # sets X-Encrypted header
+    header_name="X-Encrypted",               # customisable header name
+)
+```
+
+Pass `encryption_config` to any `CommerceMCPBase` subclass:
+
+```python
+client = MyPlatformClient(
+    app_key="...",
+    app_secret="...",
+    encryption_config=config,
+)
+```
+
+### How It Works
+
+1. **Encrypt (request)** -- When `method == "POST"` and data is present,
+   the JSON body is serialised to bytes, then encrypted. If compression is
+   also enabled, encryption is applied **before** compression. The
+   `X-Encrypted` header signals to the server that the body is encrypted.
+
+2. **Decrypt (response)** -- If the response carries the `X-Encrypted`
+   header, the body is decrypted before JSON parsing.
+
+### Standalone Usage
+
+```python
+from shared.cn_commerce_base import RequestEncryptor, EncryptionConfig, EncryptionMethod
+
+enc = RequestEncryptor(EncryptionConfig(
+    method=EncryptionMethod.AES_256_CBC,
+    encryption_key="0123456789abcdef" * 4,
+))
+
+plaintext = b'{"order_id": "12345"}'
+ciphertext, headers = enc.encrypt(plaintext)
+decrypted = enc.decrypt(ciphertext)
+assert decrypted == plaintext
+```
+
+### XOR Cipher (Testing)
+
+```python
+enc = RequestEncryptor(EncryptionConfig(
+    method=EncryptionMethod.XOR_CIPHER,
+    encryption_key="deadbeef",
+))
+encrypted, _ = enc.encrypt(b"hello world")
+assert enc.decrypt(encrypted) == b"hello world"
+```
+
+### AES-256-CBC Details
+
+- **Mode**: CBC (Cipher Block Chaining)
+- **Padding**: PKCS7
+- **IV**: 16 bytes, randomly generated per encryption, prepended to ciphertext
+- **Key**: 32 bytes (256 bits), passed as 64-char hex string
+- **Dependency**: `pyaes` (`pip install pyaes`)
+
+Ciphertext layout: `[IV (16 bytes)][encrypted blocks...]`
+
+### Statistics
+
+```python
+stats = client.get_encryption_stats()
+# {
+#     "method": "aes_256_cbc",
+#     "total_encrypted": 42,
+#     "total_decrypted": 38,
+#     "total_bytes_encrypted": 15360,
+#     "total_bytes_decrypted": 12288,
+# }
+```
+
+---
+
+## Request Audit
+
+### Overview
+
+Every request through `CommerceMCPBase._request()` is automatically logged
+to an in-memory audit log. Each entry records:
+
+- Request ID, method, path, platform
+- HTTP status code, latency
+- Whether the body was encrypted
+- Error message (if failed)
+
+### Querying
+
+```python
+# Get all errors
+errors = client.query_audit(errors_only=True, limit=50)
+
+# Filter by platform and method
+entries = client.query_audit(platform="TAOBAO", method="POST", limit=20)
+
+# Filter by path substring
+entries = client.query_audit(path="/api/order", limit=100)
+```
+
+### Statistics
+
+```python
+stats = client.get_audit_stats()
+# {
+#     "total_entries": 150,
+#     "max_entries": 50000,
+#     "error_count": 3,
+#     "encrypted_count": 42,
+#     "platforms": {"TAOBAO": 80, "DOUDIAN": 70},
+#     "methods": {"GET": 100, "POST": 50},
+# }
+```
+
+### Export
+
+```python
+# JSON
+json_str = client.export_audit_json(limit=100)
+
+# CSV
+csv_str = client.export_audit_csv(limit=100)
+
+# File
+client.get_audit_log().export_to_file("audit.json", format="json")
+client.get_audit_log().export_to_file("audit.csv", format="csv")
+```
+
+### Direct AuditLog Access
+
+```python
+from shared.cn_commerce_base import AuditLog, AuditEntry
+
+audit = AuditLog(max_entries=10000)
+audit.log(AuditEntry(
+    method="GET",
+    path="/api/products",
+    platform="TAOBAO",
+    status_code=200,
+    latency_ms=45.2,
+))
+```
+
+### Configuration
+
+The audit log is configured via `audit_max_entries` in `CommerceMCPBase.__init__`:
+
+```python
+client = MyPlatformClient(
+    app_key="...",
+    app_secret="...",
+    audit_max_entries=100000,  # default: 50000
+)
+```
+
+Old entries are automatically evicted when the limit is reached (FIFO).
+
+---
+
+## Security Notes
+
+- Encryption keys are masked in configuration output (`to_dict()`).
+- The audit log does **not** store request/response bodies -- only metadata.
+- AES-256-CBC uses a fresh random IV for every encryption, preventing
+  pattern analysis across identical payloads.
+- XOR cipher is provided for testing convenience only and must not be
+  used in production.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ all = [
     "mcp-cn-weixin-store",
 ]
 dev = ["pytest>=7.0", "pytest-asyncio", "pytest-cov", "black", "ruff"]
+crypto = ["pyaes>=1.6"]
 
 [project.scripts]
 mcp-cn-commerce = "cli:main"

--- a/shared/cn_commerce_base.py
+++ b/shared/cn_commerce_base.py
@@ -2704,10 +2704,7 @@ class RequestResultCache:
         """
         now = time.time()
         with self._lock:
-            expired_keys = [
-                k for k, (stored_at, ttl, _) in self._cache.items()
-                if now - stored_at > ttl
-            ]
+            expired_keys = [k for k, (stored_at, ttl, _) in self._cache.items() if now - stored_at > ttl]
             for k in expired_keys:
                 del self._cache[k]
             self._stats.total_evicted += len(expired_keys)
@@ -2854,6 +2851,7 @@ class ResponseDecompressor:
                 # Brotli -- attempt if available
                 try:
                     import brotli
+
                     decompressed = brotli.decompress(body)
                 except ImportError:
                     logger.warning("Brotli decompression requested but brotli not installed")
@@ -2870,10 +2868,7 @@ class ResponseDecompressor:
                 self._stats.decompressed_responses += 1
                 self._stats.total_decompressed_bytes += len(decompressed)
 
-            logger.debug(
-                f"Decompressed {len(body)} -> {len(decompressed)} bytes "
-                f"(encoding={encoding})"
-            )
+            logger.debug(f"Decompressed {len(body)} -> {len(decompressed)} bytes " f"(encoding={encoding})")
             return decompressed
 
         except Exception as exc:
@@ -3212,9 +3207,7 @@ class RequestEncryptor:
             self._total_encrypted += 1
             self._total_bytes_encrypted += len(body)
 
-        logger.debug(
-            f"Encrypted {len(body)} bytes using {self.config.method.value}"
-        )
+        logger.debug(f"Encrypted {len(body)} bytes using {self.config.method.value}")
         return encrypted, headers
 
     def decrypt(self, data: bytes) -> bytes:
@@ -3241,9 +3234,7 @@ class RequestEncryptor:
             self._total_decrypted += 1
             self._total_bytes_decrypted += len(decrypted)
 
-        logger.debug(
-            f"Decrypted {len(data)} -> {len(decrypted)} bytes using {self.config.method.value}"
-        )
+        logger.debug(f"Decrypted {len(data)} -> {len(decrypted)} bytes using {self.config.method.value}")
         return decrypted
 
     def _do_encrypt(self, body: bytes) -> bytes:
@@ -3296,10 +3287,7 @@ class RequestEncryptor:
         try:
             import pyaes
         except ImportError:
-            raise ImportError(
-                "pyaes is required for AES encryption. "
-                "Install it with: pip install pyaes"
-            )
+            raise ImportError("pyaes is required for AES encryption. " "Install it with: pip install pyaes")
 
         iv = os.urandom(16)
         padded = self._pkcs7_pad(body, 16)
@@ -3322,10 +3310,7 @@ class RequestEncryptor:
         try:
             import pyaes
         except ImportError:
-            raise ImportError(
-                "pyaes is required for AES decryption. "
-                "Install it with: pip install pyaes"
-            )
+            raise ImportError("pyaes is required for AES decryption. " "Install it with: pip install pyaes")
 
         iv = data[:16]
         ciphertext = data[16:]
@@ -3577,9 +3562,16 @@ class AuditLog:
             return ""
 
         fields = [
-            "audit_id", "request_id", "method", "path",
-            "platform", "timestamp", "status_code",
-            "latency_ms", "encrypted", "error",
+            "audit_id",
+            "request_id",
+            "method",
+            "path",
+            "platform",
+            "timestamp",
+            "status_code",
+            "latency_ms",
+            "encrypted",
+            "error",
         ]
         output = io.StringIO()
         writer = csv.DictWriter(output, fieldnames=fields, extrasaction="ignore")
@@ -3932,15 +3924,17 @@ class CommerceMCPBase:
                         self._result_cache.set(cache_key, result, ttl_seconds=cache_ttl)
 
                 # ── Audit: log successful request ──
-                self._audit_log.log(AuditEntry(
-                    request_id=request_id,
-                    method=method.upper(),
-                    path=path,
-                    platform=self.__class__.__name__.upper(),
-                    status_code=resp.status_code,
-                    latency_ms=(time.time() - request_start) * 1000,
-                    encrypted=is_encrypted,
-                ))
+                self._audit_log.log(
+                    AuditEntry(
+                        request_id=request_id,
+                        method=method.upper(),
+                        path=path,
+                        platform=self.__class__.__name__.upper(),
+                        status_code=resp.status_code,
+                        latency_ms=(time.time() - request_start) * 1000,
+                        encrypted=is_encrypted,
+                    )
+                )
 
                 return result
 
@@ -3948,16 +3942,18 @@ class CommerceMCPBase:
                 last_exc = exc
 
                 # ── Audit: log failed request ──
-                self._audit_log.log(AuditEntry(
-                    request_id=request_id,
-                    method=method.upper(),
-                    path=path,
-                    platform=self.__class__.__name__.upper(),
-                    status_code=getattr(exc, "status_code", 0),
-                    latency_ms=(time.time() - request_start) * 1000,
-                    encrypted=is_encrypted,
-                    error=str(exc),
-                ))
+                self._audit_log.log(
+                    AuditEntry(
+                        request_id=request_id,
+                        method=method.upper(),
+                        path=path,
+                        platform=self.__class__.__name__.upper(),
+                        status_code=getattr(exc, "status_code", 0),
+                        latency_ms=(time.time() - request_start) * 1000,
+                        encrypted=is_encrypted,
+                        error=str(exc),
+                    )
+                )
 
                 # If no retry config or not retryable, re-raise immediately
                 if not retry_config or not retry_config.should_retry_exception(exc):
@@ -6523,7 +6519,7 @@ class RequestRecorder:
         with self._lock:
             self._records.append(rec)
             if len(self._records) > self.config.max_records:
-                self._records = self._records[-self.config.max_records:]
+                self._records = self._records[-self.config.max_records :]
             self._stats["total_recorded"] += 1
 
         logger.debug(f"Recorded request: {rec.method} {rec.path} [{rec.record_id[:8]}]")
@@ -6590,7 +6586,7 @@ class RequestRecorder:
         with self._lock:
             self._records.extend(records)
             if len(self._records) > self.config.max_records:
-                self._records = self._records[-self.config.max_records:]
+                self._records = self._records[-self.config.max_records :]
             self._stats["total_imported"] += len(records)
         logger.debug(f"Imported {len(records)} request records")
         return len(records)
@@ -6714,7 +6710,10 @@ class RequestReplayer:
     ) -> list[dict[str, Any]]:
         """Replay filtered recorded requests."""
         records = self._recorder.filter(
-            method=method, path=path, platform=platform, tags=tags,
+            method=method,
+            path=path,
+            platform=platform,
+            tags=tags,
         )
         results: list[dict[str, Any]] = []
         for record in records:
@@ -6739,11 +6738,13 @@ class RequestReplayer:
             result = await self.replay(record, execute_fn)
             if not result["success"]:
                 mismatched += 1
-                details.append({
-                    "record_id": record.record_id,
-                    "status": "error",
-                    "error": result.get("error", ""),
-                })
+                details.append(
+                    {
+                        "record_id": record.record_id,
+                        "status": "error",
+                        "error": result.get("error", ""),
+                    }
+                )
                 continue
 
             original = record.response or {}
@@ -6751,18 +6752,22 @@ class RequestReplayer:
 
             if self._responses_match(original, new):
                 matched += 1
-                details.append({
-                    "record_id": record.record_id,
-                    "status": "matched",
-                })
+                details.append(
+                    {
+                        "record_id": record.record_id,
+                        "status": "matched",
+                    }
+                )
             else:
                 mismatched += 1
-                details.append({
-                    "record_id": record.record_id,
-                    "status": "mismatched",
-                    "original_keys": sorted(original.keys()) if isinstance(original, dict) else [],
-                    "new_keys": sorted(new.keys()) if isinstance(new, dict) else [],
-                })
+                details.append(
+                    {
+                        "record_id": record.record_id,
+                        "status": "mismatched",
+                        "original_keys": sorted(original.keys()) if isinstance(original, dict) else [],
+                        "new_keys": sorted(new.keys()) if isinstance(new, dict) else [],
+                    }
+                )
 
         self._stats["total_matched"] += matched
         self._stats["total_mismatched"] += mismatched
@@ -6841,11 +6846,13 @@ class TraceSpan:
 
     def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
         """Add a timestamped event to the span."""
-        self.events.append({
-            "name": name,
-            "timestamp": time.time(),
-            "attributes": attributes or {},
-        })
+        self.events.append(
+            {
+                "name": name,
+                "timestamp": time.time(),
+                "attributes": attributes or {},
+            }
+        )
 
     def finish(self, status: str = "ok") -> None:
         """Mark the span as finished."""
@@ -7090,7 +7097,7 @@ class DebugLogger:
         with self._lock:
             self._entries.append(entry)
             if len(self._entries) > self._max_entries:
-                self._entries = self._entries[-self._max_entries:]
+                self._entries = self._entries[-self._max_entries :]
             self._stats["total_logged"] += 1
 
         return entry
@@ -7276,12 +7283,14 @@ class DebugBreakpointManager:
 
     def _record_hit(self, bp: DebugBreakpoint, context: dict[str, Any]) -> None:
         """Record a breakpoint hit in history."""
-        self._hit_history.append({
-            "breakpoint_id": bp.breakpoint_id,
-            "name": bp.name,
-            "timestamp": time.time(),
-            "context": context,
-        })
+        self._hit_history.append(
+            {
+                "breakpoint_id": bp.breakpoint_id,
+                "name": bp.name,
+                "timestamp": time.time(),
+                "context": context,
+            }
+        )
         if len(self._hit_history) > 1000:
             self._hit_history = self._hit_history[-500:]
 

--- a/shared/cn_commerce_base.py
+++ b/shared/cn_commerce_base.py
@@ -6363,3 +6363,949 @@ class DataExporter:
             return json.dumps(data, ensure_ascii=False, indent=2, default=str)
         else:
             raise ValueError("export_to_string does not support Excel format")
+
+
+# ── Request Replay & Debug ──────────────────────────────────
+
+
+@dataclass
+class RequestRecord:
+    """A single recorded request for replay.
+
+    Attributes:
+        record_id: Unique identifier for this record.
+        method: HTTP method ("GET" or "POST").
+        path: API endpoint path.
+        params: Query parameters.
+        data: Request body data.
+        response: Captured response data.
+        status_code: HTTP status code of the response.
+        latency_ms: Request duration in milliseconds.
+        timestamp: Unix timestamp when the request was made.
+        platform: Platform identifier.
+        tags: User-defined tags for filtering.
+    """
+
+    record_id: str = ""
+    method: str = ""
+    path: str = ""
+    params: dict[str, Any] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
+    response: dict[str, Any] | None = None
+    status_code: int = 0
+    latency_ms: float = 0.0
+    timestamp: float = 0.0
+    platform: str = ""
+    tags: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.record_id:
+            self.record_id = str(uuid.uuid4())
+        if self.timestamp == 0.0:
+            self.timestamp = time.time()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary."""
+        return {
+            "record_id": self.record_id,
+            "method": self.method,
+            "path": self.path,
+            "params": self.params,
+            "data": self.data,
+            "response": self.response,
+            "status_code": self.status_code,
+            "latency_ms": round(self.latency_ms, 2),
+            "timestamp": self.timestamp,
+            "platform": self.platform,
+            "tags": self.tags,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RequestRecord:
+        """Reconstruct a RequestRecord from a dictionary."""
+        return cls(
+            record_id=data.get("record_id", ""),
+            method=data.get("method", ""),
+            path=data.get("path", ""),
+            params=data.get("params", {}),
+            data=data.get("data", {}),
+            response=data.get("response"),
+            status_code=data.get("status_code", 0),
+            latency_ms=data.get("latency_ms", 0.0),
+            timestamp=data.get("timestamp", 0.0),
+            platform=data.get("platform", ""),
+            tags=data.get("tags", []),
+        )
+
+
+@dataclass
+class ReplayConfig:
+    """Configuration for request replay behaviour.
+
+    Attributes:
+        max_records: Maximum number of records to keep in memory.
+        record_responses: Whether to store response data in records.
+        auto_record: Whether to automatically record all _request() calls.
+        replay_delay_ms: Artificial delay between replayed requests (0 = none).
+        match_strategy: How to match replay requests ("exact" or "fuzzy").
+    """
+
+    max_records: int = 1000
+    record_responses: bool = True
+    auto_record: bool = False
+    replay_delay_ms: float = 0.0
+    match_strategy: str = "exact"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary."""
+        return {
+            "max_records": self.max_records,
+            "record_responses": self.record_responses,
+            "auto_record": self.auto_record,
+            "replay_delay_ms": self.replay_delay_ms,
+            "match_strategy": self.match_strategy,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ReplayConfig:
+        """Deserialize from a dictionary."""
+        return cls(
+            max_records=data.get("max_records", 1000),
+            record_responses=data.get("record_responses", True),
+            auto_record=data.get("auto_record", False),
+            replay_delay_ms=data.get("replay_delay_ms", 0.0),
+            match_strategy=data.get("match_strategy", "exact"),
+        )
+
+
+class RequestRecorder:
+    """Records API requests for later replay and debugging.
+
+    Supports recording, filtering, exporting, and importing request records.
+    Thread-safe for concurrent access.
+    """
+
+    def __init__(self, config: ReplayConfig | None = None) -> None:
+        self.config = config or ReplayConfig()
+        self._records: list[RequestRecord] = []
+        self._lock = threading.Lock()
+        self._stats = {
+            "total_recorded": 0,
+            "total_exported": 0,
+            "total_imported": 0,
+        }
+
+    def record(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        response: dict[str, Any] | None = None,
+        status_code: int = 0,
+        latency_ms: float = 0.0,
+        platform: str = "",
+        tags: list[str] | None = None,
+    ) -> RequestRecord:
+        """Record a request."""
+        rec = RequestRecord(
+            method=method.upper(),
+            path=path,
+            params=params or {},
+            data=data or {},
+            response=response if self.config.record_responses else None,
+            status_code=status_code,
+            latency_ms=latency_ms,
+            platform=platform,
+            tags=tags or [],
+        )
+
+        with self._lock:
+            self._records.append(rec)
+            if len(self._records) > self.config.max_records:
+                self._records = self._records[-self.config.max_records:]
+            self._stats["total_recorded"] += 1
+
+        logger.debug(f"Recorded request: {rec.method} {rec.path} [{rec.record_id[:8]}]")
+        return rec
+
+    def get_records(self) -> list[RequestRecord]:
+        """Get all recorded records (copy)."""
+        with self._lock:
+            return list(self._records)
+
+    def get_record(self, record_id: str) -> RequestRecord | None:
+        """Get a specific record by ID."""
+        with self._lock:
+            for rec in self._records:
+                if rec.record_id == record_id:
+                    return rec
+        return None
+
+    def filter(
+        self,
+        method: str | None = None,
+        path: str | None = None,
+        platform: str | None = None,
+        tags: list[str] | None = None,
+        since: float | None = None,
+    ) -> list[RequestRecord]:
+        """Filter records by criteria."""
+        with self._lock:
+            results = list(self._records)
+
+        if method:
+            method_upper = method.upper()
+            results = [r for r in results if r.method == method_upper]
+        if path:
+            results = [r for r in results if path in r.path]
+        if platform:
+            results = [r for r in results if r.platform == platform]
+        if tags:
+            tag_set = set(tags)
+            results = [r for r in results if tag_set & set(r.tags)]
+        if since is not None:
+            results = [r for r in results if r.timestamp >= since]
+
+        return results
+
+    def clear(self) -> int:
+        """Remove all records. Returns count."""
+        with self._lock:
+            count = len(self._records)
+            self._records.clear()
+            return count
+
+    def export_json(self) -> str:
+        """Export all records as a JSON string."""
+        with self._lock:
+            data = [r.to_dict() for r in self._records]
+            self._stats["total_exported"] += 1
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    def import_json(self, json_str: str) -> int:
+        """Import records from a JSON string."""
+        data = json.loads(json_str)
+        records = [RequestRecord.from_dict(d) for d in data]
+        with self._lock:
+            self._records.extend(records)
+            if len(self._records) > self.config.max_records:
+                self._records = self._records[-self.config.max_records:]
+            self._stats["total_imported"] += len(records)
+        logger.debug(f"Imported {len(records)} request records")
+        return len(records)
+
+    def export_to_file(self, file_path: str) -> int:
+        """Export records to a JSON file."""
+        json_str = self.export_json()
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(json_str)
+        with self._lock:
+            count = len(self._records)
+        logger.info(f"Exported {count} records to {file_path}")
+        return count
+
+    def import_from_file(self, file_path: str) -> int:
+        """Import records from a JSON file."""
+        with open(file_path, encoding="utf-8") as f:
+            json_str = f.read()
+        return self.import_json(json_str)
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get recorder statistics."""
+        with self._lock:
+            return {
+                "record_count": len(self._records),
+                "max_records": self.config.max_records,
+                "config": self.config.to_dict(),
+                **self._stats,
+            }
+
+    def reset_stats(self) -> None:
+        """Reset collected statistics (not records)."""
+        self._stats = {
+            "total_recorded": 0,
+            "total_exported": 0,
+            "total_imported": 0,
+        }
+
+
+class RequestReplayer:
+    """Replays previously recorded requests.
+
+    Supports configurable delays and validation of replayed responses
+    against recorded ones.
+    """
+
+    def __init__(
+        self,
+        recorder: RequestRecorder,
+        config: ReplayConfig | None = None,
+    ) -> None:
+        self._recorder = recorder
+        self.config = config or recorder.config
+        self._stats = {
+            "total_replayed": 0,
+            "total_matched": 0,
+            "total_mismatched": 0,
+            "total_errors": 0,
+        }
+
+    async def replay(
+        self,
+        record: RequestRecord,
+        execute_fn: Callable[..., Awaitable[dict[str, Any]]],
+    ) -> dict[str, Any]:
+        """Replay a single recorded request."""
+        if self.config.replay_delay_ms > 0:
+            await asyncio.sleep(self.config.replay_delay_ms / 1000.0)
+
+        start = time.time()
+        try:
+            new_response = await execute_fn(
+                method=record.method,
+                path=record.path,
+                params=dict(record.params),
+                data=dict(record.data),
+            )
+            latency_ms = (time.time() - start) * 1000
+            self._stats["total_replayed"] += 1
+
+            return {
+                "record_id": record.record_id,
+                "success": True,
+                "original_response": record.response,
+                "new_response": new_response,
+                "latency_ms": round(latency_ms, 2),
+                "original_latency_ms": round(record.latency_ms, 2),
+            }
+        except Exception as exc:
+            latency_ms = (time.time() - start) * 1000
+            self._stats["total_replayed"] += 1
+            self._stats["total_errors"] += 1
+            return {
+                "record_id": record.record_id,
+                "success": False,
+                "error": str(exc),
+                "latency_ms": round(latency_ms, 2),
+                "original_latency_ms": round(record.latency_ms, 2),
+            }
+
+    async def replay_all(
+        self,
+        execute_fn: Callable[..., Awaitable[dict[str, Any]]],
+    ) -> list[dict[str, Any]]:
+        """Replay all recorded requests sequentially."""
+        records = self._recorder.get_records()
+        results: list[dict[str, Any]] = []
+        for record in records:
+            result = await self.replay(record, execute_fn)
+            results.append(result)
+        return results
+
+    async def replay_filtered(
+        self,
+        execute_fn: Callable[..., Awaitable[dict[str, Any]]],
+        method: str | None = None,
+        path: str | None = None,
+        platform: str | None = None,
+        tags: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Replay filtered recorded requests."""
+        records = self._recorder.filter(
+            method=method, path=path, platform=platform, tags=tags,
+        )
+        results: list[dict[str, Any]] = []
+        for record in records:
+            result = await self.replay(record, execute_fn)
+            results.append(result)
+        return results
+
+    async def validate_replay(
+        self,
+        execute_fn: Callable[..., Awaitable[dict[str, Any]]],
+        records: list[RequestRecord] | None = None,
+    ) -> dict[str, Any]:
+        """Replay requests and validate responses against recordings."""
+        if records is None:
+            records = self._recorder.get_records()
+
+        matched = 0
+        mismatched = 0
+        details: list[dict[str, Any]] = []
+
+        for record in records:
+            result = await self.replay(record, execute_fn)
+            if not result["success"]:
+                mismatched += 1
+                details.append({
+                    "record_id": record.record_id,
+                    "status": "error",
+                    "error": result.get("error", ""),
+                })
+                continue
+
+            original = record.response or {}
+            new = result.get("new_response", {})
+
+            if self._responses_match(original, new):
+                matched += 1
+                details.append({
+                    "record_id": record.record_id,
+                    "status": "matched",
+                })
+            else:
+                mismatched += 1
+                details.append({
+                    "record_id": record.record_id,
+                    "status": "mismatched",
+                    "original_keys": sorted(original.keys()) if isinstance(original, dict) else [],
+                    "new_keys": sorted(new.keys()) if isinstance(new, dict) else [],
+                })
+
+        self._stats["total_matched"] += matched
+        self._stats["total_mismatched"] += mismatched
+
+        return {
+            "total": len(records),
+            "matched": matched,
+            "mismatched": mismatched,
+            "match_rate": round(matched / len(records), 4) if records else 0.0,
+            "details": details,
+        }
+
+    @staticmethod
+    def _responses_match(original: Any, new: Any) -> bool:
+        """Check if two responses have matching structure."""
+        if isinstance(original, dict) and isinstance(new, dict):
+            return set(original.keys()) == set(new.keys())
+        return original == new
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get replayer statistics."""
+        return dict(self._stats)
+
+    def reset_stats(self) -> None:
+        """Reset collected statistics."""
+        self._stats = {
+            "total_replayed": 0,
+            "total_matched": 0,
+            "total_mismatched": 0,
+            "total_errors": 0,
+        }
+
+
+# ── Request Tracing (Debug) ─────────────────────────────────
+
+
+@dataclass
+class TraceSpan:
+    """A single span within a request trace.
+
+    Attributes:
+        span_id: Unique identifier for this span.
+        trace_id: Identifier for the overall trace.
+        parent_id: Parent span ID (None for root spans).
+        name: Human-readable span name.
+        start_time: Unix timestamp when the span started.
+        end_time: Unix timestamp when the span ended (0 if active).
+        duration_ms: Span duration in milliseconds.
+        status: Span status ("ok", "error", "unset").
+        attributes: Key-value metadata.
+        events: List of timestamped events within the span.
+    """
+
+    span_id: str = ""
+    trace_id: str = ""
+    parent_id: str | None = None
+    name: str = ""
+    start_time: float = 0.0
+    end_time: float = 0.0
+    duration_ms: float = 0.0
+    status: str = "unset"
+    attributes: dict[str, Any] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.span_id:
+            self.span_id = uuid.uuid4().hex[:16]
+        if not self.trace_id:
+            self.trace_id = uuid.uuid4().hex[:32]
+        if self.start_time == 0.0:
+            self.start_time = time.time()
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        """Add or update a span attribute."""
+        self.attributes[key] = value
+
+    def add_event(self, name: str, attributes: dict[str, Any] | None = None) -> None:
+        """Add a timestamped event to the span."""
+        self.events.append({
+            "name": name,
+            "timestamp": time.time(),
+            "attributes": attributes or {},
+        })
+
+    def finish(self, status: str = "ok") -> None:
+        """Mark the span as finished."""
+        self.end_time = time.time()
+        self.duration_ms = (self.end_time - self.start_time) * 1000
+        self.status = status
+
+    @property
+    def is_active(self) -> bool:
+        """Whether the span is still active (not finished)."""
+        return self.end_time == 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary."""
+        return {
+            "span_id": self.span_id,
+            "trace_id": self.trace_id,
+            "parent_id": self.parent_id,
+            "name": self.name,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "duration_ms": round(self.duration_ms, 2),
+            "status": self.status,
+            "attributes": self.attributes,
+            "events": self.events,
+        }
+
+
+class RequestTracer:
+    """Traces requests through the system with parent-child span support.
+
+    Provides lightweight distributed tracing for debugging request flows.
+    """
+
+    def __init__(self, service_name: str = "") -> None:
+        self.service_name = service_name
+        self._spans: list[TraceSpan] = []
+        self._active_spans: dict[str, TraceSpan] = {}
+        self._current_trace_id: str = ""
+        self._lock = threading.Lock()
+
+    def start_span(
+        self,
+        name: str,
+        parent: TraceSpan | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> TraceSpan:
+        """Start a new span."""
+        span = TraceSpan(
+            name=name,
+            parent_id=parent.span_id if parent else None,
+            trace_id=parent.trace_id if parent else "",
+            attributes=attributes or {},
+        )
+
+        with self._lock:
+            self._spans.append(span)
+            self._active_spans[span.span_id] = span
+            if parent is None:
+                self._current_trace_id = span.trace_id
+
+        return span
+
+    def finish_span(self, span: TraceSpan, status: str = "ok") -> None:
+        """Finish an active span."""
+        span.finish(status)
+        with self._lock:
+            self._active_spans.pop(span.span_id, None)
+
+    def get_spans(self) -> list[TraceSpan]:
+        """Get all spans (copy)."""
+        with self._lock:
+            return list(self._spans)
+
+    def get_active_spans(self) -> list[TraceSpan]:
+        """Get currently active (unfinished) spans."""
+        with self._lock:
+            return list(self._active_spans.values())
+
+    def get_trace_summary(self) -> dict[str, Any]:
+        """Get a summary of the current trace."""
+        with self._lock:
+            spans = list(self._spans)
+            active = list(self._active_spans.values())
+
+        if not spans:
+            return {
+                "trace_id": "",
+                "span_count": 0,
+                "active_span_count": 0,
+                "total_duration_ms": 0.0,
+                "root_span": "",
+                "status": "unset",
+                "service_name": self.service_name,
+            }
+
+        trace_id = spans[0].trace_id
+        root_spans = [s for s in spans if s.parent_id is None]
+        root_name = root_spans[0].name if root_spans else ""
+
+        total_duration = sum(s.duration_ms for s in spans if not s.is_active)
+        has_error = any(s.status == "error" for s in spans)
+        status = "error" if has_error else "ok"
+
+        return {
+            "trace_id": trace_id,
+            "span_count": len(spans),
+            "active_span_count": len(active),
+            "total_duration_ms": round(total_duration, 2),
+            "root_span": root_name,
+            "status": status,
+            "service_name": self.service_name,
+        }
+
+    def clear(self) -> None:
+        """Remove all spans."""
+        with self._lock:
+            self._spans.clear()
+            self._active_spans.clear()
+            self._current_trace_id = ""
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get tracer statistics."""
+        with self._lock:
+            return {
+                "service_name": self.service_name,
+                "total_spans": len(self._spans),
+                "active_spans": len(self._active_spans),
+                "current_trace_id": self._current_trace_id,
+            }
+
+
+# ── Debug Logging ───────────────────────────────────────────
+
+
+class DebugLogLevel(StrEnum):
+    """Debug log levels."""
+
+    TRACE = "trace"
+    DEBUG = "debug"
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+
+
+_DEBUG_LEVEL_ORDER: dict[str, int] = {
+    DebugLogLevel.TRACE: 0,
+    DebugLogLevel.DEBUG: 1,
+    DebugLogLevel.INFO: 2,
+    DebugLogLevel.WARN: 3,
+    DebugLogLevel.ERROR: 4,
+}
+
+
+@dataclass
+class DebugLogEntry:
+    """A single debug log entry."""
+
+    entry_id: str = ""
+    level: str = DebugLogLevel.DEBUG
+    message: str = ""
+    timestamp: float = 0.0
+    context: dict[str, Any] = field(default_factory=dict)
+    trace_id: str = ""
+    span_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.entry_id:
+            self.entry_id = uuid.uuid4().hex[:12]
+        if self.timestamp == 0.0:
+            self.timestamp = time.time()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary."""
+        return {
+            "entry_id": self.entry_id,
+            "level": self.level,
+            "message": self.message,
+            "timestamp": self.timestamp,
+            "context": self.context,
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+        }
+
+
+class DebugLogger:
+    """Structured debug logger for request debugging.
+
+    Captures debug log entries with levels, context, and trace correlation.
+    Thread-safe for concurrent access.
+    """
+
+    def __init__(
+        self,
+        level: DebugLogLevel | str = DebugLogLevel.DEBUG,
+        max_entries: int = 5000,
+    ) -> None:
+        self._level = level if isinstance(level, str) else level.value
+        self._max_entries = max_entries
+        self._entries: list[DebugLogEntry] = []
+        self._lock = threading.Lock()
+        self._stats = {"total_logged": 0, "total_filtered": 0}
+
+    @property
+    def level(self) -> str:
+        """Current minimum log level."""
+        return self._level
+
+    @level.setter
+    def level(self, value: str | DebugLogLevel) -> None:
+        """Update the minimum log level."""
+        self._level = value if isinstance(value, str) else value.value
+
+    def _should_log(self, level: str) -> bool:
+        """Check if a message at this level should be captured."""
+        return _DEBUG_LEVEL_ORDER.get(level, 0) >= _DEBUG_LEVEL_ORDER.get(self._level, 0)
+
+    def log(
+        self,
+        level: str | DebugLogLevel,
+        message: str,
+        context: dict[str, Any] | None = None,
+        trace_id: str = "",
+        span_id: str = "",
+    ) -> DebugLogEntry | None:
+        """Log a debug entry."""
+        level_str = level if isinstance(level, str) else level.value
+
+        if not self._should_log(level_str):
+            with self._lock:
+                self._stats["total_filtered"] += 1
+            return None
+
+        entry = DebugLogEntry(
+            level=level_str,
+            message=message,
+            context=context or {},
+            trace_id=trace_id,
+            span_id=span_id,
+        )
+
+        with self._lock:
+            self._entries.append(entry)
+            if len(self._entries) > self._max_entries:
+                self._entries = self._entries[-self._max_entries:]
+            self._stats["total_logged"] += 1
+
+        return entry
+
+    def get_entries(
+        self,
+        level: str | None = None,
+        trace_id: str | None = None,
+        limit: int = 100,
+    ) -> list[DebugLogEntry]:
+        """Get log entries with optional filtering."""
+        with self._lock:
+            entries = list(self._entries)
+
+        if level:
+            min_order = _DEBUG_LEVEL_ORDER.get(level, 0)
+            entries = [e for e in entries if _DEBUG_LEVEL_ORDER.get(e.level, 0) >= min_order]
+        if trace_id:
+            entries = [e for e in entries if e.trace_id == trace_id]
+
+        return entries[-limit:]
+
+    def export_json(self) -> str:
+        """Export all entries as JSON string."""
+        with self._lock:
+            data = [e.to_dict() for e in self._entries]
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+    def clear(self) -> int:
+        """Remove all entries. Returns count."""
+        with self._lock:
+            count = len(self._entries)
+            self._entries.clear()
+            return count
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get logger statistics."""
+        with self._lock:
+            return {
+                "entry_count": len(self._entries),
+                "max_entries": self._max_entries,
+                "level": self._level,
+                **self._stats,
+            }
+
+
+# ── Debug Breakpoints ───────────────────────────────────────
+
+
+@dataclass
+class DebugBreakpoint:
+    """A configurable debug breakpoint for request debugging."""
+
+    breakpoint_id: str = ""
+    name: str = ""
+    enabled: bool = True
+    condition: Callable[..., bool] | None = field(default=None, repr=False)
+    hit_count: int = 0
+    action: str = "log"
+    tags: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.breakpoint_id:
+            self.breakpoint_id = uuid.uuid4().hex[:12]
+
+    def evaluate(self, **kwargs: Any) -> bool:
+        """Evaluate whether this breakpoint should trigger."""
+        if not self.enabled:
+            return False
+        if self.condition is None:
+            return True
+        try:
+            return self.condition(**kwargs)
+        except Exception:
+            return False
+
+    def hit(self) -> None:
+        """Record a breakpoint hit."""
+        self.hit_count += 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to a JSON-serializable dictionary (excludes condition callable)."""
+        return {
+            "breakpoint_id": self.breakpoint_id,
+            "name": self.name,
+            "enabled": self.enabled,
+            "hit_count": self.hit_count,
+            "action": self.action,
+            "tags": self.tags,
+            "has_condition": self.condition is not None,
+        }
+
+
+class DebugBreakpointManager:
+    """Manages debug breakpoints for request debugging."""
+
+    def __init__(self) -> None:
+        self._breakpoints: dict[str, DebugBreakpoint] = {}
+        self._lock = threading.Lock()
+        self._stats = {"total_checks": 0, "total_hits": 0}
+        self._hit_history: list[dict[str, Any]] = []
+
+    def add_breakpoint(
+        self,
+        name: str = "",
+        action: str = "log",
+        condition: Callable[..., bool] | None = None,
+        tags: list[str] | None = None,
+    ) -> DebugBreakpoint:
+        """Add a new breakpoint."""
+        bp = DebugBreakpoint(
+            name=name,
+            action=action,
+            condition=condition,
+            tags=tags or [],
+        )
+        with self._lock:
+            self._breakpoints[bp.breakpoint_id] = bp
+        logger.debug(f"Breakpoint added: {bp.name} [{bp.breakpoint_id}]")
+        return bp
+
+    def remove_breakpoint(self, breakpoint_id: str) -> bool:
+        """Remove a breakpoint by ID."""
+        with self._lock:
+            if breakpoint_id in self._breakpoints:
+                del self._breakpoints[breakpoint_id]
+                return True
+        return False
+
+    def enable_breakpoint(self, breakpoint_id: str) -> bool:
+        """Enable a breakpoint."""
+        with self._lock:
+            bp = self._breakpoints.get(breakpoint_id)
+            if bp:
+                bp.enabled = True
+                return True
+        return False
+
+    def disable_breakpoint(self, breakpoint_id: str) -> bool:
+        """Disable a breakpoint."""
+        with self._lock:
+            bp = self._breakpoints.get(breakpoint_id)
+            if bp:
+                bp.enabled = False
+                return True
+        return False
+
+    def get_breakpoint(self, breakpoint_id: str) -> DebugBreakpoint | None:
+        """Get a breakpoint by ID."""
+        with self._lock:
+            return self._breakpoints.get(breakpoint_id)
+
+    def list_breakpoints(
+        self,
+        enabled_only: bool = False,
+        tags: list[str] | None = None,
+    ) -> list[DebugBreakpoint]:
+        """List breakpoints with optional filtering."""
+        with self._lock:
+            bps = list(self._breakpoints.values())
+        if enabled_only:
+            bps = [bp for bp in bps if bp.enabled]
+        if tags:
+            tag_set = set(tags)
+            bps = [bp for bp in bps if tag_set & set(bp.tags)]
+        return bps
+
+    def should_break(self, **kwargs: Any) -> DebugBreakpoint | None:
+        """Check if any breakpoint should trigger."""
+        with self._lock:
+            self._stats["total_checks"] += 1
+            bps = [bp for bp in self._breakpoints.values() if bp.enabled]
+
+        for bp in bps:
+            if bp.evaluate(**kwargs):
+                bp.hit()
+                self._record_hit(bp, kwargs)
+                with self._lock:
+                    self._stats["total_hits"] += 1
+                return bp
+
+        return None
+
+    def _record_hit(self, bp: DebugBreakpoint, context: dict[str, Any]) -> None:
+        """Record a breakpoint hit in history."""
+        self._hit_history.append({
+            "breakpoint_id": bp.breakpoint_id,
+            "name": bp.name,
+            "timestamp": time.time(),
+            "context": context,
+        })
+        if len(self._hit_history) > 1000:
+            self._hit_history = self._hit_history[-500:]
+
+    def get_hit_history(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Get recent breakpoint hit history."""
+        return self._hit_history[-limit:]
+
+    def clear(self) -> None:
+        """Remove all breakpoints and clear history."""
+        with self._lock:
+            self._breakpoints.clear()
+            self._hit_history.clear()
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get breakpoint manager statistics."""
+        with self._lock:
+            return {
+                "breakpoint_count": len(self._breakpoints),
+                "enabled_count": sum(1 for bp in self._breakpoints.values() if bp.enabled),
+                **self._stats,
+                "hit_history_count": len(self._hit_history),
+            }
+
+    def reset_stats(self) -> None:
+        """Reset collected statistics."""
+        self._stats = {"total_checks": 0, "total_hits": 0}
+        self._hit_history.clear()

--- a/tests/test_cn_commerce_base.py
+++ b/tests/test_cn_commerce_base.py
@@ -25,6 +25,8 @@ if str(_shared_dir) not in sys.path:
 from cn_commerce_base import (
     DEFAULT_RETRY,
     RATE_LIMIT_RETRY,
+    AuditEntry,
+    AuditLog,
     BatchRequestItem,
     BatchResultItem,
     BatchSummary,
@@ -36,6 +38,8 @@ from cn_commerce_base import (
     ConfigurableRateLimiter,
     ConfigValidationError,
     DecompressionStats,
+    EncryptionConfig,
+    EncryptionMethod,
     EndpointMetrics,
     EndpointRateLimit,
     MetricsCollector,
@@ -50,6 +54,7 @@ from cn_commerce_base import (
     RequestCacheConfig,
     RequestCacheStats,
     RequestCompressor,
+    RequestEncryptor,
     RequestPriority,
     RequestResultCache,
     ResponseDecompressor,
@@ -4441,3 +4446,752 @@ class TestCommerceMCPBaseCacheAndCompression:
         assert client._result_cache.config.max_size == 32
         assert client._compressor.config.method == CompressionMethod.GZIP
         assert client._configurable_limiter.config.default_requests_per_second == 5.0
+
+
+# ── EncryptionMethod Tests ─────────────────────────────────
+
+
+class TestEncryptionMethod:
+    """Tests for EncryptionMethod enum values."""
+
+    def test_none_value(self):
+        assert EncryptionMethod.NONE == "none"
+
+    def test_aes_256_cbc_value(self):
+        assert EncryptionMethod.AES_256_CBC == "aes_256_cbc"
+
+    def test_xor_cipher_value(self):
+        assert EncryptionMethod.XOR_CIPHER == "xor_cipher"
+
+    def test_all_methods(self):
+        methods = list(EncryptionMethod)
+        assert len(methods) == 3
+
+
+# ── EncryptionConfig Tests ─────────────────────────────────
+
+
+class TestEncryptionConfig:
+    """Tests for EncryptionConfig dataclass."""
+
+    def test_default_config(self):
+        cfg = EncryptionConfig()
+        assert cfg.method == EncryptionMethod.NONE
+        assert cfg.encryption_key == ""
+        assert cfg.include_encrypted_header is True
+        assert cfg.header_name == "X-Encrypted"
+
+    def test_to_dict_masks_key(self):
+        cfg = EncryptionConfig(
+            method=EncryptionMethod.AES_256_CBC,
+            encryption_key="0123456789abcdef" * 4,
+        )
+        d = cfg.to_dict()
+        assert d["method"] == "aes_256_cbc"
+        assert "****" in d["encryption_key"]
+        assert d["encryption_key"] != "0123456789abcdef" * 4
+
+    def test_to_dict_empty_key(self):
+        cfg = EncryptionConfig(encryption_key="")
+        d = cfg.to_dict()
+        assert d["encryption_key"] == ""
+
+    def test_from_dict(self):
+        data = {
+            "method": "xor_cipher",
+            "encryption_key": "abcdef",
+            "include_encrypted_header": False,
+            "header_name": "X-Custom",
+        }
+        cfg = EncryptionConfig.from_dict(data)
+        assert cfg.method == EncryptionMethod.XOR_CIPHER
+        assert cfg.encryption_key == "abcdef"
+        assert cfg.include_encrypted_header is False
+        assert cfg.header_name == "X-Custom"
+
+    def test_from_dict_defaults(self):
+        cfg = EncryptionConfig.from_dict({})
+        assert cfg.method == EncryptionMethod.NONE
+        assert cfg.encryption_key == ""
+
+
+# ── RequestEncryptor Tests ─────────────────────────────────
+
+
+class TestRequestEncryptor:
+    """Tests for RequestEncryptor encrypt/decrypt."""
+
+    def test_none_encryption_passthrough(self):
+        enc = RequestEncryptor(EncryptionConfig(method=EncryptionMethod.NONE))
+        body = b'{"test": true}'
+        result, headers = enc.encrypt(body)
+        assert result == body
+        assert headers == {}
+
+    def test_none_decryption_passthrough(self):
+        enc = RequestEncryptor(EncryptionConfig(method=EncryptionMethod.NONE))
+        data = b'{"test": true}'
+        result = enc.decrypt(data)
+        assert result == data
+
+    def test_xor_encrypt_decrypt_roundtrip(self):
+        key = "deadbeef"
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key=key,
+        ))
+        plaintext = b'{"order_id": "12345", "amount": 100}'
+        encrypted, headers = enc.encrypt(plaintext)
+
+        assert encrypted != plaintext
+        assert headers["X-Encrypted"] == "xor_cipher"
+
+        decrypted = enc.decrypt(encrypted)
+        assert decrypted == plaintext
+
+    def test_xor_empty_body(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="ff",
+        ))
+        encrypted, _ = enc.encrypt(b"")
+        assert encrypted == b""
+        assert enc.decrypt(encrypted) == b""
+
+    def test_xor_custom_header_name(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="aa",
+            header_name="X-Custom-Encrypt",
+        ))
+        _, headers = enc.encrypt(b"data")
+        assert "X-Custom-Encrypt" in headers
+        assert "X-Encrypted" not in headers
+
+    def test_xor_no_header_when_disabled(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="aa",
+            include_encrypted_header=False,
+        ))
+        _, headers = enc.encrypt(b"data")
+        assert headers == {}
+
+    def test_missing_key_raises(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="",
+        ))
+        with pytest.raises(ValueError, match="Encryption key is required"):
+            enc.encrypt(b"data")
+
+    def test_missing_key_decrypt_raises(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="",
+        ))
+        with pytest.raises(ValueError, match="Encryption key is required"):
+            enc.decrypt(b"data")
+
+    def test_xor_key_cannot_be_empty(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="",
+        ))
+        with pytest.raises(ValueError):
+            enc._xor_encrypt(b"test", b"")
+
+    def test_xor_large_body(self):
+        key = "1234567890abcdef"
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key=key,
+        ))
+        body = os.urandom(10000)
+        encrypted, _ = enc.encrypt(body)
+        assert len(encrypted) == len(body)
+        assert enc.decrypt(encrypted) == body
+
+    def test_pkcs7_pad_unpad(self):
+        data = b"hello"
+        padded = RequestEncryptor._pkcs7_pad(data, 16)
+        assert len(padded) % 16 == 0
+        assert RequestEncryptor._pkcs7_unpad(padded) == data
+
+    def test_pkcs7_pad_full_block(self):
+        data = b"0123456789abcdef"  # exactly 16 bytes
+        padded = RequestEncryptor._pkcs7_pad(data, 16)
+        assert len(padded) == 32  # adds a full padding block
+        assert RequestEncryptor._pkcs7_unpad(padded) == data
+
+    def test_pkcs7_unpad_invalid(self):
+        with pytest.raises(ValueError, match="Cannot unpad empty data"):
+            RequestEncryptor._pkcs7_unpad(b"")
+
+    def test_pkcs7_unpad_bad_length(self):
+        with pytest.raises(ValueError, match="Invalid PKCS7 padding length"):
+            RequestEncryptor._pkcs7_unpad(b"\x00" + b"\x11" * 15)
+
+    def test_aes_wrong_key_length(self):
+        # 8 bytes hex = 4 bytes key (not 32)
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.AES_256_CBC,
+            encryption_key="aabbccdd",
+        ))
+        with pytest.raises(ValueError, match="32-byte key"):
+            enc.encrypt(b"data")
+
+    def test_aes_decrypt_short_data(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.AES_256_CBC,
+            encryption_key="00" * 32,
+        ))
+        with pytest.raises(ValueError, match="too short"):
+            enc.decrypt(b"short")
+
+    def test_aes_encrypt_decrypt_roundtrip(self):
+        """Test AES-256-CBC encrypt/decrypt roundtrip (requires pyaes)."""
+        pyaes = pytest.importorskip("pyaes")
+        key = "0123456789abcdef" * 4  # 32 bytes
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.AES_256_CBC,
+            encryption_key=key,
+        ))
+        plaintext = b'{"product_id": "SKU-001", "price": 99.99}'
+        encrypted, headers = enc.encrypt(plaintext)
+
+        assert encrypted != plaintext
+        assert len(encrypted) > len(plaintext)  # IV + padding
+        assert headers["X-Encrypted"] == "aes_256_cbc"
+
+        decrypted = enc.decrypt(encrypted)
+        assert decrypted == plaintext
+
+    def test_aes_different_iv_each_time(self):
+        """Each AES encryption should produce different ciphertext (random IV)."""
+        pyaes = pytest.importorskip("pyaes")
+        key = "aabbccdd" * 8
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.AES_256_CBC,
+            encryption_key=key,
+        ))
+        body = b"same plaintext"
+        r1, _ = enc.encrypt(body)
+        r2, _ = enc.encrypt(body)
+        # IVs are different, so ciphertexts differ
+        assert r1 != r2
+        # But both decrypt to the same plaintext
+        assert enc.decrypt(r1) == body
+        assert enc.decrypt(r2) == body
+
+    def test_encryption_stats(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="ab",
+        ))
+        enc.encrypt(b"hello")
+        enc.encrypt(b"world")
+        enc.decrypt(b"data")
+
+        stats = enc.get_stats()
+        assert stats["total_encrypted"] == 2
+        assert stats["total_decrypted"] == 1
+        assert stats["total_bytes_encrypted"] == 10
+        assert stats["total_bytes_decrypted"] == 4
+
+    def test_encryption_stats_reset(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="ab",
+        ))
+        enc.encrypt(b"hello")
+        enc.reset_stats()
+        stats = enc.get_stats()
+        assert stats["total_encrypted"] == 0
+
+    def test_unsupported_method_raises(self):
+        enc = RequestEncryptor(EncryptionConfig(
+            method=EncryptionMethod.NONE,
+            encryption_key="ab",
+        ))
+        # Force an invalid method for testing
+        enc.config.method = "invalid"
+        with pytest.raises(ValueError, match="Unsupported encryption method"):
+            enc.encrypt(b"data")
+
+
+# ── AuditEntry Tests ───────────────────────────────────────
+
+
+class TestAuditEntry:
+    """Tests for AuditEntry dataclass."""
+
+    def test_defaults(self):
+        entry = AuditEntry()
+        assert entry.audit_id  # auto-generated UUID
+        assert entry.timestamp  # auto-generated ISO 8601
+        assert entry.method == ""
+        assert entry.status_code == 0
+        assert entry.encrypted is False
+
+    def test_custom_values(self):
+        entry = AuditEntry(
+            method="GET",
+            path="/api/order",
+            platform="TAOBAO",
+            status_code=200,
+            latency_ms=45.2,
+            encrypted=True,
+        )
+        d = entry.to_dict()
+        assert d["method"] == "GET"
+        assert d["path"] == "/api/order"
+        assert d["platform"] == "TAOBAO"
+        assert d["status_code"] == 200
+        assert d["latency_ms"] == 45.2
+        assert d["encrypted"] is True
+
+    def test_to_dict_structure(self):
+        entry = AuditEntry(
+            method="POST",
+            path="/api/test",
+            error="timeout",
+        )
+        d = entry.to_dict()
+        assert "audit_id" in d
+        assert "request_id" in d
+        assert "timestamp" in d
+        assert d["error"] == "timeout"
+
+    def test_metadata(self):
+        entry = AuditEntry(metadata={"user_id": "U001", "ip": "10.0.0.1"})
+        d = entry.to_dict()
+        assert d["metadata"]["user_id"] == "U001"
+
+
+# ── AuditLog Tests ─────────────────────────────────────────
+
+
+class TestAuditLog:
+    """Tests for AuditLog class."""
+
+    def test_empty_log(self):
+        log = AuditLog()
+        assert log.entry_count == 0
+        assert log.query() == []
+
+    def test_log_single_entry(self):
+        log = AuditLog()
+        entry = AuditEntry(method="GET", path="/api/test", platform="TAOBAO")
+        log.log(entry)
+        assert log.entry_count == 1
+
+    def test_query_all(self):
+        log = AuditLog()
+        for i in range(5):
+            log.log(AuditEntry(method="GET", path=f"/api/item/{i}"))
+        results = log.query(limit=10)
+        assert len(results) == 5
+
+    def test_query_by_platform(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a", platform="TAOBAO"))
+        log.log(AuditEntry(method="GET", path="/b", platform="DOUDIAN"))
+        log.log(AuditEntry(method="GET", path="/c", platform="TAOBAO"))
+
+        results = log.query(platform="TAOBAO")
+        assert len(results) == 2
+
+    def test_query_by_method(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a"))
+        log.log(AuditEntry(method="POST", path="/b"))
+        log.log(AuditEntry(method="GET", path="/c"))
+
+        results = log.query(method="POST")
+        assert len(results) == 1
+
+    def test_query_by_path(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/api/order/1"))
+        log.log(AuditEntry(method="GET", path="/api/product/2"))
+        log.log(AuditEntry(method="GET", path="/api/order/3"))
+
+        results = log.query(path="/api/order")
+        assert len(results) == 2
+
+    def test_query_by_status_code(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a", status_code=200))
+        log.log(AuditEntry(method="GET", path="/b", status_code=500))
+        log.log(AuditEntry(method="GET", path="/c", status_code=200))
+
+        results = log.query(status_code=500)
+        assert len(results) == 1
+
+    def test_query_errors_only(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a"))
+        log.log(AuditEntry(method="GET", path="/b", error="timeout"))
+        log.log(AuditEntry(method="GET", path="/c"))
+
+        results = log.query(errors_only=True)
+        assert len(results) == 1
+
+    def test_query_encrypted_only(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="POST", path="/a", encrypted=True))
+        log.log(AuditEntry(method="POST", path="/b", encrypted=False))
+        log.log(AuditEntry(method="POST", path="/c", encrypted=True))
+
+        results = log.query(encrypted_only=True)
+        assert len(results) == 2
+
+    def test_query_latency_filter(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a", latency_ms=10.0))
+        log.log(AuditEntry(method="GET", path="/b", latency_ms=100.0))
+        log.log(AuditEntry(method="GET", path="/c", latency_ms=500.0))
+
+        results = log.query(min_latency_ms=50.0)
+        assert len(results) == 2
+
+        results = log.query(max_latency_ms=100.0)
+        assert len(results) == 2
+
+    def test_query_pagination(self):
+        log = AuditLog()
+        for i in range(20):
+            log.log(AuditEntry(method="GET", path=f"/api/{i}"))
+
+        page1 = log.query(limit=5, offset=0)
+        page2 = log.query(limit=5, offset=5)
+        assert len(page1) == 5
+        assert len(page2) == 5
+        # Results are most-recent-first, so different pages have different entries
+        assert page1[0]["audit_id"] != page2[0]["audit_id"]
+
+    def test_max_entries_eviction(self):
+        log = AuditLog(max_entries=5)
+        for i in range(10):
+            log.log(AuditEntry(method="GET", path=f"/api/{i}"))
+        assert log.entry_count == 5
+
+    def test_combined_filters(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="POST", path="/api/order", platform="TAOBAO", status_code=200))
+        log.log(AuditEntry(method="POST", path="/api/order", platform="DOUDIAN", status_code=200))
+        log.log(AuditEntry(method="GET", path="/api/order", platform="TAOBAO", status_code=200))
+
+        results = log.query(platform="TAOBAO", method="POST")
+        assert len(results) == 1
+
+    def test_stats_empty(self):
+        log = AuditLog()
+        stats = log.get_stats()
+        assert stats["total_entries"] == 0
+        assert stats["error_count"] == 0
+
+    def test_stats_with_entries(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a", platform="TAOBAO", encrypted=True))
+        log.log(AuditEntry(method="POST", path="/b", platform="TAOBAO", error="fail"))
+        log.log(AuditEntry(method="GET", path="/c", platform="DOUDIAN"))
+
+        stats = log.get_stats()
+        assert stats["total_entries"] == 3
+        assert stats["error_count"] == 1
+        assert stats["encrypted_count"] == 1
+        assert stats["platforms"]["TAOBAO"] == 2
+        assert stats["platforms"]["DOUDIAN"] == 1
+        assert stats["methods"]["GET"] == 2
+        assert stats["methods"]["POST"] == 1
+
+    def test_export_json(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/api/test"))
+        json_str = log.export_json()
+        data = json.loads(json_str)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["method"] == "GET"
+
+    def test_export_json_with_limit(self):
+        log = AuditLog()
+        for i in range(10):
+            log.log(AuditEntry(method="GET", path=f"/api/{i}"))
+        json_str = log.export_json(limit=3)
+        data = json.loads(json_str)
+        assert len(data) == 3
+
+    def test_export_csv(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/api/test", platform="TAOBAO"))
+        csv_str = log.export_csv()
+        assert "method" in csv_str
+        assert "GET" in csv_str
+
+    def test_export_csv_empty(self):
+        log = AuditLog()
+        assert log.export_csv() == ""
+
+    def test_export_to_file_json(self, tmp_path):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/api/test"))
+        file_path = str(tmp_path / "audit.json")
+        result = log.export_to_file(file_path, format="json")
+        assert result == file_path
+        with open(file_path) as f:
+            data = json.loads(f.read())
+        assert len(data) == 1
+
+    def test_export_to_file_csv(self, tmp_path):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/api/test"))
+        file_path = str(tmp_path / "audit.csv")
+        result = log.export_to_file(file_path, format="csv")
+        assert result == file_path
+        with open(file_path) as f:
+            content = f.read()
+        assert "GET" in content
+
+    def test_export_to_file_invalid_format(self, tmp_path):
+        log = AuditLog()
+        with pytest.raises(ValueError, match="Unsupported export format"):
+            log.export_to_file(str(tmp_path / "out.xml"), format="xml")
+
+    def test_clear(self):
+        log = AuditLog()
+        log.log(AuditEntry(method="GET", path="/a"))
+        log.log(AuditEntry(method="GET", path="/b"))
+        count = log.clear()
+        assert count == 2
+        assert log.entry_count == 0
+
+
+# ── CommerceMCPBase Encryption Integration ──────────────────
+
+
+class TestCommerceMCPBaseEncryption:
+    """Integration tests for encryption in CommerceMCPBase."""
+
+    def test_default_no_encryption(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        assert client._encryptor.config.method == EncryptionMethod.NONE
+
+    def test_custom_encryption_config(self):
+        cfg = EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="aabb",
+        )
+        client = CommerceMCPBase(app_key="k", app_secret="s", encryption_config=cfg)
+        assert client._encryptor.config.method == EncryptionMethod.XOR_CIPHER
+
+    def test_get_encryption_stats(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        stats = client.get_encryption_stats()
+        assert "method" in stats
+        assert stats["method"] == "none"
+
+    def test_get_encryption_config(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        cfg = client.get_encryption_config()
+        assert cfg["method"] == "none"
+
+    @pytest.mark.asyncio
+    async def test_xor_encrypted_post_request(self):
+        """POST request with XOR encryption should encrypt body and add header."""
+        cfg = EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="abcdef01",
+        )
+        client = CommerceMCPBase(app_key="k", app_secret="s", encryption_config=cfg)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "ok"}
+        mock_response.status_code = 200
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.is_closed = False
+
+        with patch.object(client, "_ensure_client", return_value=mock_client):
+            result = await client._request("POST", "/api/test", data={"key": "value"})
+
+        assert result == {"result": "ok"}
+        # Verify post was called (encryption happened)
+        mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_encrypted_request_logged_in_audit(self):
+        """Encrypted requests should be logged with encrypted=True."""
+        cfg = EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="ab",
+        )
+        client = CommerceMCPBase(app_key="k", app_secret="s", encryption_config=cfg)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": True}
+        mock_response.status_code = 200
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.is_closed = False
+
+        with patch.object(client, "_ensure_client", return_value=mock_client):
+            await client._request("POST", "/api/test", data={"a": 1})
+
+        entries = client.query_audit(limit=10)
+        assert len(entries) == 1
+        assert entries[0]["encrypted"] is True
+
+
+# ── CommerceMCPBase Audit Integration ───────────────────────
+
+
+class TestCommerceMCPBaseAudit:
+    """Integration tests for audit logging in CommerceMCPBase."""
+
+    def test_default_audit_log(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        assert isinstance(client._audit_log, AuditLog)
+
+    def test_custom_audit_max_entries(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s", audit_max_entries=1000)
+        assert client._audit_log._max_entries == 1000
+
+    @pytest.mark.asyncio
+    async def test_request_logged_in_audit(self):
+        """Successful requests should be logged."""
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": "ok"}
+        mock_response.status_code = 200
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
+
+        with patch.object(client, "_ensure_client", return_value=mock_client):
+            await client._request("GET", "/api/products")
+
+        stats = client.get_audit_stats()
+        assert stats["total_entries"] == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_request_logged_with_error(self):
+        """Failed requests should include error message."""
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.ConnectError("Connection refused")
+        mock_client.is_closed = False
+
+        with patch.object(client, "_ensure_client", return_value=mock_client):
+            with pytest.raises(httpx.ConnectError):
+                await client._request("GET", "/api/test")
+
+        entries = client.query_audit(errors_only=True)
+        assert len(entries) == 1
+        assert "Connection refused" in entries[0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_audit_records_platform(self):
+        """Audit entries should include the platform name."""
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": 1}
+        mock_response.status_code = 200
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.is_closed = False
+
+        with patch.object(client, "_ensure_client", return_value=mock_client):
+            await client._request("GET", "/api/test")
+
+        entries = client.query_audit()
+        assert entries[0]["platform"] == "COMMERCEMCPBASE"
+
+    def test_query_audit_convenience(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        # Should not raise
+        results = client.query_audit(limit=10)
+        assert isinstance(results, list)
+
+    def test_export_audit_json(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        json_str = client.export_audit_json()
+        assert json.loads(json_str) == []
+
+    def test_export_audit_csv(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        csv_str = client.export_audit_csv()
+        assert csv_str == ""
+
+    def test_get_audit_log(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        log = client.get_audit_log()
+        assert isinstance(log, AuditLog)
+
+
+# ── CommerceMCPBase Encryption + Audit Combined ─────────────
+
+
+class TestCommerceMCPBaseEncryptionAuditCombined:
+    """Tests for combined encryption and audit features."""
+
+    def test_all_new_features_initialized(self):
+        """Client should have encryptor and audit log."""
+        client = CommerceMCPBase()
+        assert isinstance(client._encryptor, RequestEncryptor)
+        assert isinstance(client._audit_log, AuditLog)
+
+    def test_custom_configs_combined(self):
+        """All custom configs should be accepted together."""
+        enc_cfg = EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="aabb",
+        )
+        client = CommerceMCPBase(
+            app_key="k",
+            app_secret="s",
+            encryption_config=enc_cfg,
+            audit_max_entries=5000,
+        )
+        assert client._encryptor.config.method == EncryptionMethod.XOR_CIPHER
+        assert client._audit_log._max_entries == 5000
+
+    @pytest.mark.asyncio
+    async def test_encrypted_request_appears_in_audit_export(self):
+        """Encrypted request should appear in JSON export."""
+        cfg = EncryptionConfig(
+            method=EncryptionMethod.XOR_CIPHER,
+            encryption_key="abcd",
+        )
+        client = CommerceMCPBase(app_key="k", app_secret="s", encryption_config=cfg)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"ok": 1}
+        mock_response.status_code = 200
+        mock_response.headers = {}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.is_closed = False
+
+        with patch.object(client, "_ensure_client", return_value=mock_client):
+            await client._request("POST", "/api/order", data={"item": "test"})
+
+        json_str = client.export_audit_json()
+        entries = json.loads(json_str)
+        assert len(entries) == 1
+        assert entries[0]["encrypted"] is True
+        assert entries[0]["method"] == "POST"

--- a/tests/test_cn_commerce_base.py
+++ b/tests/test_cn_commerce_base.py
@@ -3821,6 +3821,7 @@ class TestRequestResultCache:
         key = RequestResultCache.make_key("GET", "/api/test")
         cache.set(key, {"result": "ok"})
         import time as _time
+
         _time.sleep(0.01)
         assert cache.get(key) is None
 
@@ -3892,6 +3893,7 @@ class TestRequestResultCache:
         cache.set("k1", {"a": 1})
         cache.set("k2", {"b": 2})
         import time as _time
+
         _time.sleep(0.01)
         removed = cache.cleanup_expired()
         assert removed == 2
@@ -4331,9 +4333,7 @@ class TestCommerceMCPBaseResultCache:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                mock_response.json.return_value = {
-                    "error_response": {"code": 40001, "msg": "bad"}
-                }
+                mock_response.json.return_value = {"error_response": {"code": 40001, "msg": "bad"}}
             else:
                 mock_response.json.return_value = {"result": "ok"}
             mock_response.status_code = 200
@@ -4378,9 +4378,7 @@ class TestCommerceMCPBaseDecompression:
 
         client = CommerceMCPBase(app_key="k", app_secret="s")
         original_data = {"result": {"products": list(range(100))}}
-        compressed_body = gzip_mod.compress(
-            json.dumps(original_data, ensure_ascii=False).encode()
-        )
+        compressed_body = gzip_mod.compress(json.dumps(original_data, ensure_ascii=False).encode())
 
         mock_response = MagicMock()
         mock_response.content = compressed_body
@@ -4536,10 +4534,12 @@ class TestRequestEncryptor:
 
     def test_xor_encrypt_decrypt_roundtrip(self):
         key = "deadbeef"
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key=key,
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key=key,
+            )
+        )
         plaintext = b'{"order_id": "12345", "amount": 100}'
         encrypted, headers = enc.encrypt(plaintext)
 
@@ -4550,63 +4550,77 @@ class TestRequestEncryptor:
         assert decrypted == plaintext
 
     def test_xor_empty_body(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="ff",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="ff",
+            )
+        )
         encrypted, _ = enc.encrypt(b"")
         assert encrypted == b""
         assert enc.decrypt(encrypted) == b""
 
     def test_xor_custom_header_name(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="aa",
-            header_name="X-Custom-Encrypt",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="aa",
+                header_name="X-Custom-Encrypt",
+            )
+        )
         _, headers = enc.encrypt(b"data")
         assert "X-Custom-Encrypt" in headers
         assert "X-Encrypted" not in headers
 
     def test_xor_no_header_when_disabled(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="aa",
-            include_encrypted_header=False,
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="aa",
+                include_encrypted_header=False,
+            )
+        )
         _, headers = enc.encrypt(b"data")
         assert headers == {}
 
     def test_missing_key_raises(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="",
+            )
+        )
         with pytest.raises(ValueError, match="Encryption key is required"):
             enc.encrypt(b"data")
 
     def test_missing_key_decrypt_raises(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="",
+            )
+        )
         with pytest.raises(ValueError, match="Encryption key is required"):
             enc.decrypt(b"data")
 
     def test_xor_key_cannot_be_empty(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="",
+            )
+        )
         with pytest.raises(ValueError):
             enc._xor_encrypt(b"test", b"")
 
     def test_xor_large_body(self):
         key = "1234567890abcdef"
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key=key,
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key=key,
+            )
+        )
         body = os.urandom(10000)
         encrypted, _ = enc.encrypt(body)
         assert len(encrypted) == len(body)
@@ -4634,18 +4648,22 @@ class TestRequestEncryptor:
 
     def test_aes_wrong_key_length(self):
         # 8 bytes hex = 4 bytes key (not 32)
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.AES_256_CBC,
-            encryption_key="aabbccdd",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.AES_256_CBC,
+                encryption_key="aabbccdd",
+            )
+        )
         with pytest.raises(ValueError, match="32-byte key"):
             enc.encrypt(b"data")
 
     def test_aes_decrypt_short_data(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.AES_256_CBC,
-            encryption_key="00" * 32,
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.AES_256_CBC,
+                encryption_key="00" * 32,
+            )
+        )
         with pytest.raises(ValueError, match="too short"):
             enc.decrypt(b"short")
 
@@ -4653,10 +4671,12 @@ class TestRequestEncryptor:
         """Test AES-256-CBC encrypt/decrypt roundtrip (requires pyaes)."""
         pyaes = pytest.importorskip("pyaes")
         key = "0123456789abcdef" * 4  # 32 bytes
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.AES_256_CBC,
-            encryption_key=key,
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.AES_256_CBC,
+                encryption_key=key,
+            )
+        )
         plaintext = b'{"product_id": "SKU-001", "price": 99.99}'
         encrypted, headers = enc.encrypt(plaintext)
 
@@ -4671,10 +4691,12 @@ class TestRequestEncryptor:
         """Each AES encryption should produce different ciphertext (random IV)."""
         pyaes = pytest.importorskip("pyaes")
         key = "aabbccdd" * 8
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.AES_256_CBC,
-            encryption_key=key,
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.AES_256_CBC,
+                encryption_key=key,
+            )
+        )
         body = b"same plaintext"
         r1, _ = enc.encrypt(body)
         r2, _ = enc.encrypt(body)
@@ -4685,10 +4707,12 @@ class TestRequestEncryptor:
         assert enc.decrypt(r2) == body
 
     def test_encryption_stats(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="ab",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="ab",
+            )
+        )
         enc.encrypt(b"hello")
         enc.encrypt(b"world")
         enc.decrypt(b"data")
@@ -4700,20 +4724,24 @@ class TestRequestEncryptor:
         assert stats["total_bytes_decrypted"] == 4
 
     def test_encryption_stats_reset(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.XOR_CIPHER,
-            encryption_key="ab",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.XOR_CIPHER,
+                encryption_key="ab",
+            )
+        )
         enc.encrypt(b"hello")
         enc.reset_stats()
         stats = enc.get_stats()
         assert stats["total_encrypted"] == 0
 
     def test_unsupported_method_raises(self):
-        enc = RequestEncryptor(EncryptionConfig(
-            method=EncryptionMethod.NONE,
-            encryption_key="ab",
-        ))
+        enc = RequestEncryptor(
+            EncryptionConfig(
+                method=EncryptionMethod.NONE,
+                encryption_key="ab",
+            )
+        )
         # Force an invalid method for testing
         enc.config.method = "invalid"
         with pytest.raises(ValueError, match="Unsupported encryption method"):


### PR DESCRIPTION
## Summary

Adds request body encryption and audit logging to the shared commerce base.

### Request Encryption
- EncryptionMethod: NONE, AES_256_CBC, XOR_CIPHER
- AES-256-CBC: Random IV per encryption, PKCS7 padding, requires pyaes (pure Python)
- XOR Cipher: Built-in, for testing only
- Encrypts POST bodies before compression; X-Encrypted header signals encryption
- Response decryption when server returns X-Encrypted header
- Key masked in EncryptionConfig.to_dict()

### Request Audit
- AuditEntry: request_id, method, path, platform, status_code, latency_ms, encrypted flag, error
- AuditLog: Thread-safe, max_entries eviction (FIFO)
- Query: Filter by platform, method, path, status_code, latency, encrypted/errors only
- Export: JSON, CSV, file
- Automatic logging in CommerceMCPBase._request() for all requests

### Files Changed
- shared/cn_commerce_base.py: +EncryptionMethod, EncryptionConfig, RequestEncryptor, AuditEntry, AuditLog; updated __init__ and _request
- tests/test_cn_commerce_base.py: +52 new tests (501 total)
- docs/request-encryption.md: documentation
- pyproject.toml: added pyaes>=1.6 as optional crypto dependency

### Tests
All 1120 tests pass (501 in test_cn_commerce_base.py).
