### PR TITLE
feat: add monitoring alerting system

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,6 +1,6 @@
-# Monitoring & Health Checks
+# Monitoring, Health Checks & Alerting
 
-mcp-cn-commerce provides built-in monitoring and health check capabilities in the shared base module.
+mcp-cn-commerce provides built-in monitoring, health check, and alerting capabilities in the shared base module.
 
 ## MetricsCollector
 
@@ -58,7 +58,7 @@ client.metrics.reset()
 | `total_latency_ms` | `float` | Cumulative latency in milliseconds |
 | `min_latency_ms` | `float` | Fastest request latency |
 | `max_latency_ms` | `float` | Slowest request latency |
-| `last_error_code` | `int \| None` | Most recent error code |
+| `last_error_code` | `int | None` | Most recent error code |
 | `last_error_msg` | `str` | Most recent error message |
 
 Computed properties: `avg_latency_ms`, `error_rate`.
@@ -80,11 +80,10 @@ Computed properties: `avg_latency_ms`, `error_rate`.
 status = await client.health_check()
 print(status)
 # {
-#   "platform": "https://api.example.com",
+#   "status": "healthy",
 #   "configured": True,
 #   "has_token": True,
 #   "api_reachable": True,
-#   "status_code": 200,
 #   "latency_ms": 45.23,
 #   "metrics": { ... }  # full metrics summary
 # }
@@ -100,14 +99,172 @@ else:
 
 | Field | Type | Description |
 |---|---|---|
-| `platform` | `str` | The `BASE_URL` being checked |
+| `status` | `str` | Overall status: "healthy", "degraded", or "unhealthy" |
 | `configured` | `bool` | Whether `app_key` and `app_secret` are set |
 | `has_token` | `bool` | Whether `access_token` is set |
 | `api_reachable` | `bool` | Whether the HEAD request succeeded (< 500) |
-| `status_code` | `int` | HTTP status code (if request completed) |
 | `latency_ms` | `float` | Round-trip latency in milliseconds |
 | `error` | `str` | Error description (if unreachable) |
 | `metrics` | `dict` | Full `MetricsCollector.get_summary()` output |
+| `cached` | `bool` | Whether the result was served from cache |
+
+### Deep Health Check
+
+For dependency-aware health checking, use `deep_health_check()`:
+
+```python
+result = await client.deep_health_check(
+    dependencies=["https://cache.example.com", "https://db.example.com"],
+    timeout=10.0,
+)
+# result includes "dependencies" dict with per-dependency status
+```
+
+## Alerting
+
+The alerting system evaluates metrics against configurable rules and fires notifications when thresholds are breached.
+
+### Quick Start
+
+```python
+from cn_commerce_base import AlertRule, AlertSeverity
+
+client = CommerceMCPBase(app_key="...", app_secret="...")
+
+# Add a custom alert rule
+client.alert_manager.add_rule(AlertRule(
+    name="high_error_rate",
+    description="Error rate exceeds 20%",
+    metric_path="global.error_rate",
+    threshold=0.2,
+    comparison="gt",
+    severity=AlertSeverity.HIGH,
+    cooldown_seconds=600.0,
+))
+
+# Register a notification callback
+def on_alert(alert):
+    print(f"ALERT: {alert.message}")
+
+client.alert_manager.notifier.add_callback(on_alert)
+
+# Evaluate and fire alerts
+results = await client.check_and_fire_alerts(platform="OCEANENGINE")
+```
+
+### Default Alert Rules
+
+mcp-cn-commerce ships with four built-in alert rules:
+
+| Name | Metric | Threshold | Severity | Cooldown |
+|---|---|---|---|---|
+| `high_error_rate` | `global.error_rate` | > 0.10 | HIGH | 300s |
+| `critical_error_rate` | `global.error_rate` | > 0.50 | CRITICAL | 60s |
+| `high_latency` | `global.avg_latency_ms` | > 5000ms | MEDIUM | 600s |
+| `critical_latency` | `global.avg_latency_ms` | > 30000ms | HIGH | 120s |
+
+### AlertRule
+
+Defines when an alert should fire.
+
+| Field | Type | Description |
+|---|---|---|
+| `rule_id` | `str` | Auto-generated unique ID |
+| `name` | `str` | Human-readable name |
+| `description` | `str` | What triggers this alert |
+| `metric_path` | `str` | Dot-separated path to metric (e.g., `global.error_rate`) |
+| `threshold` | `float` | Numeric threshold value |
+| `comparison` | `str` | Operator: `gt`, `gte`, `lt`, `lte`, `eq` |
+| `severity` | `str` | `critical`, `high`, `medium`, or `low` |
+| `cooldown_seconds` | `float` | Minimum seconds between consecutive alerts |
+| `enabled` | `bool` | Whether the rule is active |
+| `tags` | `list[str]` | User-defined tags for filtering |
+| `platform` | `str` | Platform filter (empty = all) |
+| `endpoint` | `str` | Endpoint filter (empty = all) |
+
+### Alert Severity Levels
+
+| Level | Description |
+|---|---|
+| `CRITICAL` | Immediate action required. Service down or data loss. |
+| `HIGH` | Urgent attention needed. Significant degradation. |
+| `MEDIUM` | Warning condition. May escalate if unaddressed. |
+| `LOW` | Informational. Track but no immediate action. |
+
+### Alert (Fired Instance)
+
+Represents a single alert that was triggered.
+
+| Field | Type | Description |
+|---|---|---|
+| `alert_id` | `str` | Auto-generated unique ID |
+| `rule_id` | `str` | ID of the rule that triggered |
+| `rule_name` | `str` | Name of the rule |
+| `severity` | `str` | Alert severity level |
+| `message` | `str` | Human-readable alert message |
+| `metric_value` | `float` | The metric value that triggered the alert |
+| `threshold` | `float` | The threshold that was exceeded |
+| `metric_path` | `str` | The metric path that was evaluated |
+| `fired_at` | `str` | ISO 8601 timestamp of when the alert fired |
+| `resolved_at` | `str` | ISO 8601 timestamp of resolution (if resolved) |
+| `status` | `str` | `firing`, `resolved`, or `silenced` |
+
+### AlertNotifier
+
+Manages notification delivery channels.
+
+```python
+# Add notification callbacks (sync or async)
+client.alert_manager.notifier.add_callback(lambda alert: print(alert.message))
+
+async def send_to_webhook(alert):
+    await httpx.AsyncClient().post("https://hooks.slack.com/...", json=alert.to_dict())
+
+client.alert_manager.notifier.add_callback(send_to_webhook)
+```
+
+### AlertManager
+
+The central component that ties rules, metrics, and notifications together.
+
+```python
+manager = client.alert_manager
+
+# List current rules
+rules = manager.list_rules(enabled_only=True)
+
+# Get firing alerts
+firing = manager.get_firing_alerts(severity=AlertSeverity.CRITICAL)
+
+# Resolve an alert
+manager.resolve_alert(alert_id)
+
+# Silence a rule temporarily
+manager.silence_rule(rule_id, duration_seconds=3600)
+
+# Get alert history
+history = manager.get_alert_history(severity=AlertSeverity.HIGH, limit=100)
+
+# Export/import rules
+rules_json = manager.export_rules()
+manager.import_rules(rules_json)
+
+# Get stats
+stats = manager.get_alert_stats()
+```
+
+### Metric Paths
+
+Use dot-separated paths to reference metrics from the MetricsCollector summary:
+
+| Path | Description |
+|---|---|
+| `global.error_rate` | Global error rate (0.0 - 1.0) |
+| `global.avg_latency_ms` | Global average latency |
+| `global.total_requests` | Total request count |
+| `global.total_errors` | Total error count |
+| `endpoints.<path>.error_rate` | Per-endpoint error rate |
+| `endpoints.<path>.avg_latency_ms` | Per-endpoint average latency |
 
 ## Integrating with External Monitoring
 
@@ -130,4 +287,13 @@ async def health_endpoint():
     if status["api_reachable"]:
         return {"status": "healthy"}, 200
     return {"status": "unhealthy", "error": status.get("error")}, 503
+
+# Alert endpoint for monitoring dashboard
+async def alert_endpoint():
+    alerts = server.alert_manager.get_firing_alerts()
+    return {
+        "firing_count": len(alerts),
+        "alerts": [a.to_dict() for a in alerts],
+        "stats": server.get_alert_stats(),
+    }
 ```

--- a/shared/cn_commerce_base.py
+++ b/shared/cn_commerce_base.py
@@ -2690,6 +2690,7 @@ class CommerceMCPBase:
         self._compressor = RequestCompressor(compression_config)
         self._configurable_limiter = ConfigurableRateLimiter(rate_limit_config)
         self._priority_scheduler = PriorityScheduler(rate_limiter=self._configurable_limiter)
+        self._alert_manager = AlertManager()
 
     def _get_client(self) -> httpx.AsyncClient:
         """Get or create an HTTP client with connection pooling.
@@ -3174,6 +3175,57 @@ class CommerceMCPBase:
     def auto_adjust_rate_limits(self, **kwargs: Any) -> dict[str, Any]:
         """Auto-adjust rate limits based on throttle statistics."""
         return self._configurable_limiter.auto_adjust_from_stats(**kwargs)
+
+    # ── Alerting Convenience ───────────────────────────────
+
+    @property
+    def alert_manager(self) -> AlertManager:
+        """Access the alert manager."""
+        return self._alert_manager
+
+    def evaluate_alerts(
+        self,
+        platform: str = "",
+        endpoint: str = "",
+    ) -> list[Alert]:
+        """Evaluate current metrics against alert rules.
+
+        Args:
+            platform: Current platform context.
+            endpoint: Current endpoint context.
+
+        Returns:
+            List of triggered Alert instances.
+        """
+        summary = self.metrics.get_summary()
+        return self._alert_manager.evaluate_metrics(summary, platform=platform, endpoint=endpoint)
+
+    async def check_and_fire_alerts(
+        self,
+        platform: str = "",
+        endpoint: str = "",
+    ) -> list[dict[str, Any]]:
+        """Evaluate metrics and fire any triggered alerts.
+
+        Combines evaluate_alerts and fire_alert in a single call.
+
+        Args:
+            platform: Current platform context.
+            endpoint: Current endpoint context.
+
+        Returns:
+            List of notification results for fired alerts.
+        """
+        alerts = self.evaluate_alerts(platform=platform, endpoint=endpoint)
+        results: list[dict[str, Any]] = []
+        for alert in alerts:
+            result = await self._alert_manager.fire_alert(alert)
+            results.append(result)
+        return results
+
+    def get_alert_stats(self) -> dict[str, Any]:
+        """Get alert manager statistics."""
+        return self._alert_manager.get_stats()
 
     # ── Batch Operations ──────────────────────────────────
 
@@ -6119,3 +6171,669 @@ class DebugBreakpointManager:
         """Reset collected statistics."""
         self._stats = {"total_checks": 0, "total_hits": 0}
         self._hit_history.clear()
+
+
+# ── Alerting ────────────────────────────────────────────────
+
+
+class AlertSeverity(StrEnum):
+    """Severity levels for monitoring alerts.
+
+    Attributes:
+        CRITICAL: Immediate action required. Service down or data loss.
+        HIGH: Urgent attention needed. Significant degradation.
+        MEDIUM: Warning condition. May escalate if unaddressed.
+        LOW: Informational. Track but no immediate action.
+    """
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+_ALERT_SEVERITY_ORDER: dict[str, int] = {
+    AlertSeverity.LOW: 0,
+    AlertSeverity.MEDIUM: 1,
+    AlertSeverity.HIGH: 2,
+    AlertSeverity.CRITICAL: 3,
+}
+
+
+@dataclass
+class AlertRule:
+    """Defines a monitoring alert rule.
+
+    Attributes:
+        rule_id: Unique identifier for the rule.
+        name: Human-readable rule name.
+        description: What condition triggers this alert.
+        metric_path: Dot-separated path to the metric value
+            (e.g., "global.error_rate", "global.avg_latency_ms").
+        threshold: Numeric threshold that triggers the alert.
+        comparison: Comparison operator ("gt", "gte", "lt", "lte", "eq").
+        severity: Alert severity level.
+        cooldown_seconds: Minimum seconds between consecutive alerts for this rule.
+        enabled: Whether the rule is active.
+        tags: User-defined tags for filtering and grouping.
+        platform: Platform filter (empty = all platforms).
+        endpoint: Endpoint filter (empty = all endpoints).
+    """
+
+    rule_id: str = ""
+    name: str = ""
+    description: str = ""
+    metric_path: str = ""
+    threshold: float = 0.0
+    comparison: str = "gt"
+    severity: str = AlertSeverity.MEDIUM
+    cooldown_seconds: float = 300.0
+    enabled: bool = True
+    tags: list[str] = field(default_factory=list)
+    platform: str = ""
+    endpoint: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.rule_id:
+            self.rule_id = uuid.uuid4().hex[:12]
+        if not self.name:
+            self.name = f"rule_{self.rule_id}"
+
+    def evaluate(self, value: float) -> bool:
+        """Evaluate if the metric value triggers this rule.
+
+        Args:
+            value: The current metric value.
+
+        Returns:
+            True if the alert should fire.
+        """
+        if self.comparison == "gt":
+            return value > self.threshold
+        elif self.comparison == "gte":
+            return value >= self.threshold
+        elif self.comparison == "lt":
+            return value < self.threshold
+        elif self.comparison == "lte":
+            return value <= self.threshold
+        elif self.comparison == "eq":
+            return value == self.threshold
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dictionary."""
+        return {
+            "rule_id": self.rule_id,
+            "name": self.name,
+            "description": self.description,
+            "metric_path": self.metric_path,
+            "threshold": self.threshold,
+            "comparison": self.comparison,
+            "severity": self.severity,
+            "cooldown_seconds": self.cooldown_seconds,
+            "enabled": self.enabled,
+            "tags": self.tags,
+            "platform": self.platform,
+            "endpoint": self.endpoint,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AlertRule:
+        """Deserialize from a dictionary."""
+        return cls(
+            rule_id=data.get("rule_id", ""),
+            name=data.get("name", ""),
+            description=data.get("description", ""),
+            metric_path=data.get("metric_path", ""),
+            threshold=data.get("threshold", 0.0),
+            comparison=data.get("comparison", "gt"),
+            severity=data.get("severity", AlertSeverity.MEDIUM),
+            cooldown_seconds=data.get("cooldown_seconds", 300.0),
+            enabled=data.get("enabled", True),
+            tags=data.get("tags", []),
+            platform=data.get("platform", ""),
+            endpoint=data.get("endpoint", ""),
+        )
+
+
+@dataclass
+class Alert:
+    """Represents a fired alert instance.
+
+    Attributes:
+        alert_id: Unique identifier for this alert instance.
+        rule_id: ID of the rule that triggered this alert.
+        rule_name: Name of the rule for quick reference.
+        severity: Alert severity level.
+        message: Human-readable alert message.
+        metric_value: The metric value that triggered the alert.
+        threshold: The threshold that was exceeded.
+        metric_path: The metric path that was evaluated.
+        platform: Platform where the alert was triggered (if applicable).
+        endpoint: Endpoint where the alert was triggered (if applicable).
+        fired_at: ISO 8601 timestamp of when the alert fired.
+        resolved_at: ISO 8601 timestamp of when the alert was resolved.
+        status: Alert status ("firing", "resolved", "silenced").
+    """
+
+    alert_id: str = ""
+    rule_id: str = ""
+    rule_name: str = ""
+    severity: str = AlertSeverity.MEDIUM
+    message: str = ""
+    metric_value: float = 0.0
+    threshold: float = 0.0
+    metric_path: str = ""
+    platform: str = ""
+    endpoint: str = ""
+    fired_at: str = ""
+    resolved_at: str = ""
+    status: str = "firing"
+
+    def __post_init__(self) -> None:
+        if not self.alert_id:
+            self.alert_id = uuid.uuid4().hex[:16]
+        if not self.fired_at:
+            self.fired_at = datetime.now(UTC).isoformat()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert alert to a dictionary."""
+        return {
+            "alert_id": self.alert_id,
+            "rule_id": self.rule_id,
+            "rule_name": self.rule_name,
+            "severity": self.severity,
+            "message": self.message,
+            "metric_value": round(self.metric_value, 4),
+            "threshold": self.threshold,
+            "metric_path": self.metric_path,
+            "platform": self.platform,
+            "endpoint": self.endpoint,
+            "fired_at": self.fired_at,
+            "resolved_at": self.resolved_at,
+            "status": self.status,
+        }
+
+
+class AlertNotifier:
+    """Base class for alert notification delivery.
+
+    Supports registering multiple notification channels (callbacks).
+    Each callback receives an Alert and returns None.
+
+    Usage::
+
+        notifier = AlertNotifier()
+        notifier.add_callback(lambda alert: print(f"ALERT: {alert.message}"))
+        await notifier.notify(alert)
+    """
+
+    def __init__(self) -> None:
+        self._callbacks: list[Callable[..., Any]] = []
+        self._lock = threading.Lock()
+        self._stats = {
+            "total_notifications": 0,
+            "total_success": 0,
+            "total_failed": 0,
+        }
+
+    def add_callback(self, callback: Callable[..., Any]) -> None:
+        """Register a notification callback.
+
+        Args:
+            callback: Function that receives an Alert instance.
+                      Can be sync or async.
+        """
+        with self._lock:
+            self._callbacks.append(callback)
+
+    def remove_callback(self, callback: Callable[..., Any]) -> bool:
+        """Remove a registered callback.
+
+        Args:
+            callback: The callback to remove.
+
+        Returns:
+            True if found and removed.
+        """
+        with self._lock:
+            if callback in self._callbacks:
+                self._callbacks.remove(callback)
+                return True
+        return False
+
+    async def notify(self, alert: Alert) -> dict[str, Any]:
+        """Send alert to all registered notification callbacks.
+
+        Args:
+            alert: The Alert to deliver.
+
+        Returns:
+            Dict with notification results.
+        """
+        with self._lock:
+            callbacks = list(self._callbacks)
+
+        results: list[dict[str, Any]] = []
+        for callback in callbacks:
+            try:
+                result = callback(alert)
+                if asyncio.iscoroutine(result) or asyncio.isfuture(result):
+                    await result
+                self._stats["total_success"] += 1
+                results.append({"callback": callback.__name__, "success": True})
+            except Exception as exc:
+                self._stats["total_failed"] += 1
+                results.append({"callback": callback.__name__, "success": False, "error": str(exc)})
+                logger.warning(f"Alert notification failed: {exc}")
+
+        self._stats["total_notifications"] += 1
+        return {
+            "alert_id": alert.alert_id,
+            "channels_notified": len(callbacks),
+            "results": results,
+        }
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get notifier statistics."""
+        with self._lock:
+            return {
+                "registered_callbacks": len(self._callbacks),
+                **self._stats,
+            }
+
+    def reset_stats(self) -> None:
+        """Reset notification statistics."""
+        self._stats = {
+            "total_notifications": 0,
+            "total_success": 0,
+            "total_failed": 0,
+        }
+
+
+# Default alert rules for common e-commerce monitoring scenarios
+DEFAULT_ALERT_RULES: list[AlertRule] = [
+    AlertRule(
+        name="high_error_rate",
+        description="Global error rate exceeds 10%",
+        metric_path="global.error_rate",
+        threshold=0.1,
+        comparison="gt",
+        severity=AlertSeverity.HIGH,
+        cooldown_seconds=300.0,
+    ),
+    AlertRule(
+        name="critical_error_rate",
+        description="Global error rate exceeds 50%",
+        metric_path="global.error_rate",
+        threshold=0.5,
+        comparison="gt",
+        severity=AlertSeverity.CRITICAL,
+        cooldown_seconds=60.0,
+    ),
+    AlertRule(
+        name="high_latency",
+        description="Average latency exceeds 5000ms",
+        metric_path="global.avg_latency_ms",
+        threshold=5000.0,
+        comparison="gt",
+        severity=AlertSeverity.MEDIUM,
+        cooldown_seconds=600.0,
+    ),
+    AlertRule(
+        name="critical_latency",
+        description="Average latency exceeds 30000ms",
+        metric_path="global.avg_latency_ms",
+        threshold=30000.0,
+        comparison="gt",
+        severity=AlertSeverity.HIGH,
+        cooldown_seconds=120.0,
+    ),
+]
+
+
+class AlertManager:
+    """Manages alert rules, evaluates metrics, and fires alerts.
+
+    Integrates with MetricsCollector to periodically evaluate metrics
+    against configured rules and trigger notifications via AlertNotifier.
+
+    Usage::
+
+        manager = AlertManager()
+        manager.add_rule(AlertRule(
+            name="high_error_rate",
+            metric_path="global.error_rate",
+            threshold=0.1,
+            comparison="gt",
+            severity="high",
+        ))
+        alerts = manager.evaluate_metrics(metrics_summary)
+        for alert in alerts:
+            await manager.fire_alert(alert)
+    """
+
+    def __init__(
+        self,
+        notifier: AlertNotifier | None = None,
+        include_default_rules: bool = True,
+    ) -> None:
+        """Initialize the alert manager.
+
+        Args:
+            notifier: AlertNotifier for delivering alerts. Creates one if None.
+            include_default_rules: Whether to include built-in default rules.
+        """
+        self._notifier = notifier or AlertNotifier()
+        self._rules: dict[str, AlertRule] = {}
+        self._firing_alerts: dict[str, Alert] = {}
+        self._alert_history: list[Alert] = []
+        self._cooldown_tracker: dict[str, float] = {}
+        self._lock = threading.Lock()
+        self._stats = {
+            "total_evaluations": 0,
+            "total_alerts_fired": 0,
+            "total_alerts_resolved": 0,
+        }
+
+        if include_default_rules:
+            for rule in DEFAULT_ALERT_RULES:
+                self.add_rule(rule)
+
+    @property
+    def notifier(self) -> AlertNotifier:
+        """Access the alert notifier."""
+        return self._notifier
+
+    def add_rule(self, rule: AlertRule) -> None:
+        """Add an alert rule.
+
+        Args:
+            rule: The AlertRule to add.
+        """
+        with self._lock:
+            self._rules[rule.rule_id] = rule
+        logger.debug(f"Alert rule added: {rule.name} [{rule.rule_id}]")
+
+    def remove_rule(self, rule_id: str) -> bool:
+        """Remove an alert rule by ID.
+
+        Args:
+            rule_id: The rule ID to remove.
+
+        Returns:
+            True if found and removed.
+        """
+        with self._lock:
+            if rule_id in self._rules:
+                del self._rules[rule_id]
+                return True
+        return False
+
+    def get_rule(self, rule_id: str) -> AlertRule | None:
+        """Get a rule by ID."""
+        with self._lock:
+            return self._rules.get(rule_id)
+
+    def list_rules(
+        self,
+        enabled_only: bool = False,
+        severity: str | None = None,
+        tags: list[str] | None = None,
+    ) -> list[AlertRule]:
+        """List rules with optional filtering.
+
+        Args:
+            enabled_only: Only return enabled rules.
+            severity: Filter by severity level.
+            tags: Filter by tags (any match).
+
+        Returns:
+            List of matching rules.
+        """
+        with self._lock:
+            rules = list(self._rules.values())
+
+        if enabled_only:
+            rules = [r for r in rules if r.enabled]
+        if severity:
+            rules = [r for r in rules if r.severity == severity]
+        if tags:
+            tag_set = set(tags)
+            rules = [r for r in rules if tag_set & set(r.tags)]
+        return rules
+
+    @staticmethod
+    def _resolve_metric_path(metrics_summary: dict[str, Any], path: str) -> float | None:
+        """Resolve a dot-separated metric path to a numeric value.
+
+        Args:
+            metrics_summary: The metrics summary dict.
+            path: Dot-separated path (e.g., "global.error_rate").
+
+        Returns:
+            The numeric value, or None if path is invalid.
+        """
+        parts = path.split(".")
+        current: Any = metrics_summary
+        for part in parts:
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                return None
+        if isinstance(current, (int, float)):
+            return float(current)
+        return None
+
+    def evaluate_metrics(
+        self,
+        metrics_summary: dict[str, Any],
+        platform: str = "",
+        endpoint: str = "",
+    ) -> list[Alert]:
+        """Evaluate all rules against the given metrics summary.
+
+        Args:
+            metrics_summary: Output of MetricsCollector.get_summary().
+            platform: Current platform context for platform-specific rules.
+            endpoint: Current endpoint context for endpoint-specific rules.
+
+        Returns:
+            List of Alert instances that should be fired.
+        """
+        now = time.time()
+        alerts: list[Alert] = []
+
+        with self._lock:
+            rules = [r for r in self._rules.values() if r.enabled]
+            self._stats["total_evaluations"] += 1
+
+        for rule in rules:
+            # Platform/endpoint filter
+            if rule.platform and platform and rule.platform != platform:
+                continue
+            if rule.endpoint and endpoint and rule.endpoint != endpoint:
+                continue
+
+            # Resolve metric value
+            value = self._resolve_metric_path(metrics_summary, rule.metric_path)
+            if value is None:
+                continue
+
+            # Evaluate the rule
+            if not rule.evaluate(value):
+                continue
+
+            # Check cooldown
+            with self._lock:
+                last_fired = self._cooldown_tracker.get(rule.rule_id, 0.0)
+                if (now - last_fired) < rule.cooldown_seconds:
+                    continue
+                self._cooldown_tracker[rule.rule_id] = now
+
+            # Create alert
+            alert = Alert(
+                rule_id=rule.rule_id,
+                rule_name=rule.name,
+                severity=rule.severity,
+                message=(
+                    f"[{rule.severity.upper()}] {rule.description}: "
+                    f"{rule.metric_path}={value:.4f} (threshold={rule.threshold})"
+                ),
+                metric_value=value,
+                threshold=rule.threshold,
+                metric_path=rule.metric_path,
+                platform=platform,
+                endpoint=endpoint,
+            )
+            alerts.append(alert)
+
+        return alerts
+
+    async def fire_alert(self, alert: Alert) -> dict[str, Any]:
+        """Fire an alert and deliver notifications.
+
+        Args:
+            alert: The Alert to fire.
+
+        Returns:
+            Notification delivery result.
+        """
+        with self._lock:
+            self._firing_alerts[alert.alert_id] = alert
+            self._alert_history.append(alert)
+            # Keep history bounded
+            if len(self._alert_history) > 1000:
+                self._alert_history = self._alert_history[-500:]
+            self._stats["total_alerts_fired"] += 1
+
+        logger.warning(f"Alert fired: {alert.message}")
+        return await self._notifier.notify(alert)
+
+    def resolve_alert(self, alert_id: str) -> bool:
+        """Mark a firing alert as resolved.
+
+        Args:
+            alert_id: ID of the alert to resolve.
+
+        Returns:
+            True if found and resolved.
+        """
+        with self._lock:
+            alert = self._firing_alerts.pop(alert_id, None)
+            if alert:
+                alert.status = "resolved"
+                alert.resolved_at = datetime.now(UTC).isoformat()
+                self._stats["total_alerts_resolved"] += 1
+                logger.info(f"Alert resolved: {alert.rule_name} [{alert.alert_id}]")
+                return True
+        return False
+
+    def silence_rule(self, rule_id: str, duration_seconds: float = 3600.0) -> bool:
+        """Silence a rule by setting its cooldown to a long duration.
+
+        Args:
+            rule_id: ID of the rule to silence.
+            duration_seconds: How long to silence (updates cooldown_seconds).
+
+        Returns:
+            True if found and silenced.
+        """
+        with self._lock:
+            rule = self._rules.get(rule_id)
+            if rule:
+                rule.cooldown_seconds = duration_seconds
+                logger.info(f"Alert rule silenced: {rule.name} for {duration_seconds}s")
+                return True
+        return False
+
+    def get_firing_alerts(self, severity: str | None = None) -> list[Alert]:
+        """Get currently firing alerts.
+
+        Args:
+            severity: Filter by severity level.
+
+        Returns:
+            List of firing Alert instances.
+        """
+        with self._lock:
+            alerts = list(self._firing_alerts.values())
+        if severity:
+            alerts = [a for a in alerts if a.severity == severity]
+        return alerts
+
+    def get_alert_history(
+        self,
+        severity: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Get alert history.
+
+        Args:
+            severity: Filter by severity level.
+            limit: Maximum entries to return.
+
+        Returns:
+            List of alert dicts.
+        """
+        with self._lock:
+            history = list(self._alert_history)
+        if severity:
+            history = [a for a in history if a.severity == severity]
+        return [a.to_dict() for a in history[-limit:]]
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get alert manager statistics.
+
+        Returns:
+            Dict with rule counts, firing alerts, and evaluation stats.
+        """
+        with self._lock:
+            return {
+                "rule_count": len(self._rules),
+                "enabled_rules": sum(1 for r in self._rules.values() if r.enabled),
+                "firing_alerts": len(self._firing_alerts),
+                "alert_history_count": len(self._alert_history),
+                "notifier_stats": self._notifier.get_stats(),
+                **self._stats,
+            }
+
+    def export_rules(self) -> list[dict[str, Any]]:
+        """Export all rules as a list of dictionaries.
+
+        Returns:
+            List of rule dicts suitable for JSON serialization.
+        """
+        with self._lock:
+            return [r.to_dict() for r in self._rules.values()]
+
+    def import_rules(self, rules_data: list[dict[str, Any]]) -> int:
+        """Import rules from a list of dictionaries.
+
+        Args:
+            rules_data: List of rule dicts (from export_rules or JSON).
+
+        Returns:
+            Number of rules imported.
+        """
+        count = 0
+        for data in rules_data:
+            rule = AlertRule.from_dict(data)
+            self.add_rule(rule)
+            count += 1
+        logger.info(f"Imported {count} alert rules")
+        return count
+
+    def reset(self) -> None:
+        """Reset all alert manager state."""
+        with self._lock:
+            self._firing_alerts.clear()
+            self._alert_history.clear()
+            self._cooldown_tracker.clear()
+            self._stats = {
+                "total_evaluations": 0,
+                "total_alerts_fired": 0,
+                "total_alerts_resolved": 0,
+            }
+            self._notifier.reset_stats()
+        logger.info("Alert manager reset")

--- a/tests/test_cn_commerce_base.py
+++ b/tests/test_cn_commerce_base.py
@@ -4237,7 +4237,8 @@ class TestAlertNotifier:
 
     def test_remove_callback(self):
         notifier = AlertNotifier()
-        cb = lambda alert: None
+        def cb(alert):
+            return None
         notifier.add_callback(cb)
         assert notifier.remove_callback(cb) is True
         assert len(notifier._callbacks) == 0
@@ -4389,12 +4390,14 @@ class TestAlertManager:
 
     def test_evaluate_metrics_triggers_alert(self):
         manager = AlertManager(include_default_rules=False)
-        manager.add_rule(AlertRule(
-            name="high_error_rate",
-            metric_path="global.error_rate",
-            threshold=0.1,
-            comparison="gt",
-        ))
+        manager.add_rule(
+            AlertRule(
+                name="high_error_rate",
+                metric_path="global.error_rate",
+                threshold=0.1,
+                comparison="gt",
+            )
+        )
         metrics_summary = {
             "global": {
                 "error_rate": 0.25,
@@ -4408,12 +4411,14 @@ class TestAlertManager:
 
     def test_evaluate_metrics_no_trigger(self):
         manager = AlertManager(include_default_rules=False)
-        manager.add_rule(AlertRule(
-            name="high_error_rate",
-            metric_path="global.error_rate",
-            threshold=0.1,
-            comparison="gt",
-        ))
+        manager.add_rule(
+            AlertRule(
+                name="high_error_rate",
+                metric_path="global.error_rate",
+                threshold=0.1,
+                comparison="gt",
+            )
+        )
         metrics_summary = {
             "global": {
                 "error_rate": 0.05,
@@ -4424,13 +4429,15 @@ class TestAlertManager:
 
     def test_evaluate_metrics_cooldown(self):
         manager = AlertManager(include_default_rules=False)
-        manager.add_rule(AlertRule(
-            name="test",
-            metric_path="global.error_rate",
-            threshold=0.1,
-            comparison="gt",
-            cooldown_seconds=999999.0,  # Very long cooldown
-        ))
+        manager.add_rule(
+            AlertRule(
+                name="test",
+                metric_path="global.error_rate",
+                threshold=0.1,
+                comparison="gt",
+                cooldown_seconds=999999.0,  # Very long cooldown
+            )
+        )
         metrics_summary = {"global": {"error_rate": 0.5}}
 
         # First evaluation fires
@@ -4443,26 +4450,30 @@ class TestAlertManager:
 
     def test_evaluate_metrics_disabled_rule_skipped(self):
         manager = AlertManager(include_default_rules=False)
-        manager.add_rule(AlertRule(
-            name="disabled",
-            metric_path="global.error_rate",
-            threshold=0.1,
-            comparison="gt",
-            enabled=False,
-        ))
+        manager.add_rule(
+            AlertRule(
+                name="disabled",
+                metric_path="global.error_rate",
+                threshold=0.1,
+                comparison="gt",
+                enabled=False,
+            )
+        )
         metrics_summary = {"global": {"error_rate": 0.5}}
         alerts = manager.evaluate_metrics(metrics_summary)
         assert len(alerts) == 0
 
     def test_evaluate_metrics_platform_filter(self):
         manager = AlertManager(include_default_rules=False)
-        manager.add_rule(AlertRule(
-            name="platform_specific",
-            metric_path="global.error_rate",
-            threshold=0.1,
-            comparison="gt",
-            platform="OCEANENGINE",
-        ))
+        manager.add_rule(
+            AlertRule(
+                name="platform_specific",
+                metric_path="global.error_rate",
+                threshold=0.1,
+                comparison="gt",
+                platform="OCEANENGINE",
+            )
+        )
         metrics_summary = {"global": {"error_rate": 0.5}}
 
         # Wrong platform
@@ -4475,11 +4486,13 @@ class TestAlertManager:
 
     def test_evaluate_metrics_invalid_metric_path(self):
         manager = AlertManager(include_default_rules=False)
-        manager.add_rule(AlertRule(
-            name="bad_path",
-            metric_path="nonexistent.path.here",
-            threshold=0.1,
-        ))
+        manager.add_rule(
+            AlertRule(
+                name="bad_path",
+                metric_path="nonexistent.path.here",
+                threshold=0.1,
+            )
+        )
         metrics_summary = {"global": {"error_rate": 0.5}}
         alerts = manager.evaluate_metrics(metrics_summary)
         assert len(alerts) == 0
@@ -4494,7 +4507,7 @@ class TestAlertManager:
 
         manager.notifier.add_callback(on_alert)
         alert = Alert(rule_name="test", message="test alert")
-        result = await manager.fire_alert(alert)
+        await manager.fire_alert(alert)
 
         assert len(received) == 1
         assert len(manager.get_firing_alerts()) == 1
@@ -4581,10 +4594,12 @@ class TestDefaultAlertRules:
 
     def test_default_rules_count(self):
         from cn_commerce_base import DEFAULT_ALERT_RULES
+
         assert len(DEFAULT_ALERT_RULES) == 4
 
     def test_default_high_error_rate(self):
         from cn_commerce_base import DEFAULT_ALERT_RULES
+
         rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "high_error_rate")
         assert rule.threshold == 0.1
         assert rule.severity == AlertSeverity.HIGH
@@ -4592,18 +4607,21 @@ class TestDefaultAlertRules:
 
     def test_default_critical_error_rate(self):
         from cn_commerce_base import DEFAULT_ALERT_RULES
+
         rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "critical_error_rate")
         assert rule.threshold == 0.5
         assert rule.severity == AlertSeverity.CRITICAL
 
     def test_default_high_latency(self):
         from cn_commerce_base import DEFAULT_ALERT_RULES
+
         rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "high_latency")
         assert rule.threshold == 5000.0
         assert rule.severity == AlertSeverity.MEDIUM
 
     def test_default_critical_latency(self):
         from cn_commerce_base import DEFAULT_ALERT_RULES
+
         rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "critical_latency")
         assert rule.threshold == 30000.0
         assert rule.severity == AlertSeverity.HIGH
@@ -4622,13 +4640,15 @@ class TestCommerceMCPBaseAlerting:
     def test_evaluate_alerts(self):
         client = CommerceMCPBase()
         # Add a rule that will trigger
-        client.alert_manager.add_rule(AlertRule(
-            name="test",
-            metric_path="global.total_requests",
-            threshold=0,
-            comparison="gt",
-            cooldown_seconds=0,
-        ))
+        client.alert_manager.add_rule(
+            AlertRule(
+                name="test",
+                metric_path="global.total_requests",
+                threshold=0,
+                comparison="gt",
+                cooldown_seconds=0,
+            )
+        )
         # Record a request so there's a metric
         client.metrics.record_request("/api/test", latency_ms=100.0, success=True)
         alerts = client.evaluate_alerts()
@@ -4652,13 +4672,15 @@ class TestCommerceMCPBaseAlerting:
             received.append(alert)
 
         client.alert_manager.notifier.add_callback(on_alert)
-        client.alert_manager.add_rule(AlertRule(
-            name="always_fire",
-            metric_path="global.total_requests",
-            threshold=-1,
-            comparison="gt",
-            cooldown_seconds=0,
-        ))
+        client.alert_manager.add_rule(
+            AlertRule(
+                name="always_fire",
+                metric_path="global.total_requests",
+                threshold=-1,
+                comparison="gt",
+                cooldown_seconds=0,
+            )
+        )
         client.metrics.record_request("/api/test", latency_ms=10.0, success=True)
         results = await client.check_and_fire_alerts()
         assert len(results) >= 1

--- a/tests/test_cn_commerce_base.py
+++ b/tests/test_cn_commerce_base.py
@@ -25,6 +25,11 @@ if str(_shared_dir) not in sys.path:
 from cn_commerce_base import (
     DEFAULT_RETRY,
     RATE_LIMIT_RETRY,
+    Alert,
+    AlertManager,
+    AlertNotifier,
+    AlertRule,
+    AlertSeverity,
     BatchRequestItem,
     BatchResultItem,
     BatchSummary,
@@ -4044,3 +4049,623 @@ class TestDebugBreakpointManager:
         stats = mgr.get_stats()
         assert stats["total_checks"] == 1
         assert stats["total_hits"] == 1
+
+
+# ── AlertSeverity Tests ────────────────────────────────────
+
+
+class TestAlertSeverity:
+    """Tests for AlertSeverity enum."""
+
+    def test_critical(self):
+        assert AlertSeverity.CRITICAL == "critical"
+
+    def test_high(self):
+        assert AlertSeverity.HIGH == "high"
+
+    def test_medium(self):
+        assert AlertSeverity.MEDIUM == "medium"
+
+    def test_low(self):
+        assert AlertSeverity.LOW == "low"
+
+
+# ── AlertRule Tests ────────────────────────────────────────
+
+
+class TestAlertRule:
+    """Tests for AlertRule dataclass."""
+
+    def test_default_values(self):
+        rule = AlertRule()
+        assert rule.rule_id != ""
+        assert rule.enabled is True
+        assert rule.cooldown_seconds == 300.0
+        assert rule.comparison == "gt"
+
+    def test_custom_values(self):
+        rule = AlertRule(
+            name="test_rule",
+            description="Test alert",
+            metric_path="global.error_rate",
+            threshold=0.5,
+            comparison="gt",
+            severity=AlertSeverity.HIGH,
+            cooldown_seconds=60.0,
+        )
+        assert rule.name == "test_rule"
+        assert rule.threshold == 0.5
+        assert rule.severity == AlertSeverity.HIGH
+
+    def test_evaluate_gt(self):
+        rule = AlertRule(metric_path="global.error_rate", threshold=0.1, comparison="gt")
+        assert rule.evaluate(0.2) is True
+        assert rule.evaluate(0.1) is False
+        assert rule.evaluate(0.05) is False
+
+    def test_evaluate_gte(self):
+        rule = AlertRule(metric_path="global.error_rate", threshold=0.1, comparison="gte")
+        assert rule.evaluate(0.2) is True
+        assert rule.evaluate(0.1) is True
+        assert rule.evaluate(0.05) is False
+
+    def test_evaluate_lt(self):
+        rule = AlertRule(metric_path="global.error_rate", threshold=0.1, comparison="lt")
+        assert rule.evaluate(0.05) is True
+        assert rule.evaluate(0.1) is False
+        assert rule.evaluate(0.2) is False
+
+    def test_evaluate_lte(self):
+        rule = AlertRule(metric_path="global.error_rate", threshold=0.1, comparison="lte")
+        assert rule.evaluate(0.05) is True
+        assert rule.evaluate(0.1) is True
+        assert rule.evaluate(0.2) is False
+
+    def test_evaluate_eq(self):
+        rule = AlertRule(metric_path="global.error_rate", threshold=0.1, comparison="eq")
+        assert rule.evaluate(0.1) is True
+        assert rule.evaluate(0.2) is False
+
+    def test_evaluate_unknown_comparison(self):
+        rule = AlertRule(metric_path="global.error_rate", threshold=0.1, comparison="unknown")
+        assert rule.evaluate(0.5) is False
+
+    def test_to_dict(self):
+        rule = AlertRule(
+            name="test",
+            metric_path="global.error_rate",
+            threshold=0.5,
+            severity=AlertSeverity.HIGH,
+        )
+        d = rule.to_dict()
+        assert d["name"] == "test"
+        assert d["threshold"] == 0.5
+        assert d["severity"] == "high"
+        assert "rule_id" in d
+
+    def test_from_dict(self):
+        data = {
+            "rule_id": "abc123",
+            "name": "test",
+            "metric_path": "global.error_rate",
+            "threshold": 0.5,
+            "comparison": "gt",
+            "severity": "high",
+            "cooldown_seconds": 60.0,
+            "enabled": True,
+            "tags": ["prod"],
+            "platform": "OCEANENGINE",
+        }
+        rule = AlertRule.from_dict(data)
+        assert rule.rule_id == "abc123"
+        assert rule.name == "test"
+        assert rule.severity == "high"
+        assert rule.platform == "OCEANENGINE"
+        assert rule.tags == ["prod"]
+
+    def test_from_dict_defaults(self):
+        rule = AlertRule.from_dict({})
+        assert rule.comparison == "gt"
+        assert rule.severity == AlertSeverity.MEDIUM
+
+    def test_roundtrip(self):
+        original = AlertRule(
+            name="roundtrip",
+            metric_path="global.avg_latency_ms",
+            threshold=1000.0,
+            severity=AlertSeverity.CRITICAL,
+        )
+        d = original.to_dict()
+        restored = AlertRule.from_dict(d)
+        assert restored.name == original.name
+        assert restored.metric_path == original.metric_path
+        assert restored.threshold == original.threshold
+        assert restored.severity == original.severity
+
+
+# ── Alert Tests ────────────────────────────────────────────
+
+
+class TestAlert:
+    """Tests for Alert dataclass."""
+
+    def test_default_values(self):
+        alert = Alert()
+        assert alert.alert_id != ""
+        assert alert.status == "firing"
+        assert alert.fired_at != ""
+        assert alert.resolved_at == ""
+
+    def test_custom_values(self):
+        alert = Alert(
+            rule_id="r1",
+            rule_name="high_error_rate",
+            severity=AlertSeverity.HIGH,
+            message="Error rate too high",
+            metric_value=0.25,
+            threshold=0.1,
+            metric_path="global.error_rate",
+        )
+        assert alert.rule_id == "r1"
+        assert alert.metric_value == 0.25
+        assert alert.severity == "high"
+
+    def test_to_dict(self):
+        alert = Alert(
+            rule_name="test",
+            severity=AlertSeverity.MEDIUM,
+            metric_value=42.0,
+            threshold=10.0,
+        )
+        d = alert.to_dict()
+        assert d["rule_name"] == "test"
+        assert d["metric_value"] == 42.0
+        assert d["threshold"] == 10.0
+        assert d["status"] == "firing"
+
+
+# ── AlertNotifier Tests ────────────────────────────────────
+
+
+class TestAlertNotifier:
+    """Tests for AlertNotifier."""
+
+    def test_add_callback(self):
+        notifier = AlertNotifier()
+        notifier.add_callback(lambda alert: None)
+        assert len(notifier._callbacks) == 1
+
+    def test_remove_callback(self):
+        notifier = AlertNotifier()
+        cb = lambda alert: None
+        notifier.add_callback(cb)
+        assert notifier.remove_callback(cb) is True
+        assert len(notifier._callbacks) == 0
+
+    def test_remove_nonexistent_callback(self):
+        notifier = AlertNotifier()
+        assert notifier.remove_callback(lambda alert: None) is False
+
+    @pytest.mark.asyncio
+    async def test_notify_sync_callback(self):
+        notifier = AlertNotifier()
+        received = []
+
+        def on_alert(alert):
+            received.append(alert)
+
+        notifier.add_callback(on_alert)
+        alert = Alert(rule_name="test", message="test alert")
+        result = await notifier.notify(alert)
+
+        assert len(received) == 1
+        assert received[0].alert_id == alert.alert_id
+        assert result["channels_notified"] == 1
+        assert result["results"][0]["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_notify_async_callback(self):
+        notifier = AlertNotifier()
+        received = []
+
+        async def on_alert(alert):
+            received.append(alert)
+
+        notifier.add_callback(on_alert)
+        alert = Alert(rule_name="test", message="async test")
+        result = await notifier.notify(alert)
+
+        assert len(received) == 1
+        assert result["channels_notified"] == 1
+
+    @pytest.mark.asyncio
+    async def test_notify_multiple_callbacks(self):
+        notifier = AlertNotifier()
+        count = [0, 0]
+
+        def cb1(alert):
+            count[0] += 1
+
+        def cb2(alert):
+            count[1] += 1
+
+        notifier.add_callback(cb1)
+        notifier.add_callback(cb2)
+        alert = Alert(rule_name="test")
+        await notifier.notify(alert)
+
+        assert count[0] == 1
+        assert count[1] == 1
+
+    @pytest.mark.asyncio
+    async def test_notify_callback_error(self):
+        notifier = AlertNotifier()
+
+        def failing_cb(alert):
+            raise RuntimeError("notification failed")
+
+        notifier.add_callback(failing_cb)
+        alert = Alert(rule_name="test")
+        result = await notifier.notify(alert)
+
+        assert result["results"][0]["success"] is False
+        assert "notification failed" in result["results"][0]["error"]
+        stats = notifier.get_stats()
+        assert stats["total_failed"] == 1
+
+    def test_get_stats(self):
+        notifier = AlertNotifier()
+        stats = notifier.get_stats()
+        assert stats["registered_callbacks"] == 0
+        assert stats["total_notifications"] == 0
+        assert stats["total_success"] == 0
+        assert stats["total_failed"] == 0
+
+    def test_reset_stats(self):
+        notifier = AlertNotifier()
+        notifier._stats["total_notifications"] = 5
+        notifier.reset_stats()
+        assert notifier._stats["total_notifications"] == 0
+
+
+# ── AlertManager Tests ─────────────────────────────────────
+
+
+class TestAlertManager:
+    """Tests for AlertManager."""
+
+    def test_default_init_includes_rules(self):
+        manager = AlertManager()
+        rules = manager.list_rules()
+        assert len(rules) == 4  # Default rules
+
+    def test_init_without_defaults(self):
+        manager = AlertManager(include_default_rules=False)
+        rules = manager.list_rules()
+        assert len(rules) == 0
+
+    def test_add_rule(self):
+        manager = AlertManager(include_default_rules=False)
+        rule = AlertRule(name="test", metric_path="global.error_rate", threshold=0.5)
+        manager.add_rule(rule)
+        assert len(manager.list_rules()) == 1
+
+    def test_remove_rule(self):
+        manager = AlertManager(include_default_rules=False)
+        rule = AlertRule(name="test", metric_path="global.error_rate", threshold=0.5)
+        manager.add_rule(rule)
+        assert manager.remove_rule(rule.rule_id) is True
+        assert len(manager.list_rules()) == 0
+
+    def test_remove_nonexistent_rule(self):
+        manager = AlertManager(include_default_rules=False)
+        assert manager.remove_rule("nonexistent") is False
+
+    def test_get_rule(self):
+        manager = AlertManager(include_default_rules=False)
+        rule = AlertRule(name="test", metric_path="global.error_rate", threshold=0.5)
+        manager.add_rule(rule)
+        retrieved = manager.get_rule(rule.rule_id)
+        assert retrieved is not None
+        assert retrieved.name == "test"
+
+    def test_list_rules_filter_enabled(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(name="enabled", enabled=True))
+        manager.add_rule(AlertRule(name="disabled", enabled=False))
+        assert len(manager.list_rules(enabled_only=True)) == 1
+
+    def test_list_rules_filter_severity(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(name="high", severity=AlertSeverity.HIGH))
+        manager.add_rule(AlertRule(name="low", severity=AlertSeverity.LOW))
+        assert len(manager.list_rules(severity=AlertSeverity.HIGH)) == 1
+
+    def test_list_rules_filter_tags(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(name="tagged", tags=["prod", "api"]))
+        manager.add_rule(AlertRule(name="untagged"))
+        assert len(manager.list_rules(tags=["prod"])) == 1
+
+    def test_evaluate_metrics_triggers_alert(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(
+            name="high_error_rate",
+            metric_path="global.error_rate",
+            threshold=0.1,
+            comparison="gt",
+        ))
+        metrics_summary = {
+            "global": {
+                "error_rate": 0.25,
+                "total_requests": 100,
+            },
+        }
+        alerts = manager.evaluate_metrics(metrics_summary)
+        assert len(alerts) == 1
+        assert alerts[0].rule_name == "high_error_rate"
+        assert alerts[0].metric_value == 0.25
+
+    def test_evaluate_metrics_no_trigger(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(
+            name="high_error_rate",
+            metric_path="global.error_rate",
+            threshold=0.1,
+            comparison="gt",
+        ))
+        metrics_summary = {
+            "global": {
+                "error_rate": 0.05,
+            },
+        }
+        alerts = manager.evaluate_metrics(metrics_summary)
+        assert len(alerts) == 0
+
+    def test_evaluate_metrics_cooldown(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(
+            name="test",
+            metric_path="global.error_rate",
+            threshold=0.1,
+            comparison="gt",
+            cooldown_seconds=999999.0,  # Very long cooldown
+        ))
+        metrics_summary = {"global": {"error_rate": 0.5}}
+
+        # First evaluation fires
+        alerts1 = manager.evaluate_metrics(metrics_summary)
+        assert len(alerts1) == 1
+
+        # Immediate second evaluation is suppressed by cooldown
+        alerts2 = manager.evaluate_metrics(metrics_summary)
+        assert len(alerts2) == 0
+
+    def test_evaluate_metrics_disabled_rule_skipped(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(
+            name="disabled",
+            metric_path="global.error_rate",
+            threshold=0.1,
+            comparison="gt",
+            enabled=False,
+        ))
+        metrics_summary = {"global": {"error_rate": 0.5}}
+        alerts = manager.evaluate_metrics(metrics_summary)
+        assert len(alerts) == 0
+
+    def test_evaluate_metrics_platform_filter(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(
+            name="platform_specific",
+            metric_path="global.error_rate",
+            threshold=0.1,
+            comparison="gt",
+            platform="OCEANENGINE",
+        ))
+        metrics_summary = {"global": {"error_rate": 0.5}}
+
+        # Wrong platform
+        alerts = manager.evaluate_metrics(metrics_summary, platform="TAOBAO")
+        assert len(alerts) == 0
+
+        # Correct platform
+        alerts = manager.evaluate_metrics(metrics_summary, platform="OCEANENGINE")
+        assert len(alerts) == 1
+
+    def test_evaluate_metrics_invalid_metric_path(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(
+            name="bad_path",
+            metric_path="nonexistent.path.here",
+            threshold=0.1,
+        ))
+        metrics_summary = {"global": {"error_rate": 0.5}}
+        alerts = manager.evaluate_metrics(metrics_summary)
+        assert len(alerts) == 0
+
+    @pytest.mark.asyncio
+    async def test_fire_alert(self):
+        manager = AlertManager(include_default_rules=False)
+        received = []
+
+        def on_alert(alert):
+            received.append(alert)
+
+        manager.notifier.add_callback(on_alert)
+        alert = Alert(rule_name="test", message="test alert")
+        result = await manager.fire_alert(alert)
+
+        assert len(received) == 1
+        assert len(manager.get_firing_alerts()) == 1
+        stats = manager.get_stats()
+        assert stats["total_alerts_fired"] == 1
+
+    def test_resolve_alert(self):
+        manager = AlertManager(include_default_rules=False)
+        alert = Alert(rule_name="test")
+        manager._firing_alerts[alert.alert_id] = alert
+
+        assert manager.resolve_alert(alert.alert_id) is True
+        assert len(manager.get_firing_alerts()) == 0
+        assert alert.status == "resolved"
+        assert alert.resolved_at != ""
+
+    def test_resolve_nonexistent_alert(self):
+        manager = AlertManager(include_default_rules=False)
+        assert manager.resolve_alert("nonexistent") is False
+
+    def test_silence_rule(self):
+        manager = AlertManager(include_default_rules=False)
+        rule = AlertRule(name="test", metric_path="global.error_rate", cooldown_seconds=60.0)
+        manager.add_rule(rule)
+        assert manager.silence_rule(rule.rule_id, duration_seconds=3600) is True
+        assert manager.get_rule(rule.rule_id).cooldown_seconds == 3600.0
+
+    def test_silence_nonexistent_rule(self):
+        manager = AlertManager(include_default_rules=False)
+        assert manager.silence_rule("nonexistent") is False
+
+    def test_get_firing_alerts_filter_severity(self):
+        manager = AlertManager(include_default_rules=False)
+        manager._firing_alerts["a1"] = Alert(severity=AlertSeverity.HIGH)
+        manager._firing_alerts["a2"] = Alert(severity=AlertSeverity.LOW)
+
+        high_alerts = manager.get_firing_alerts(severity=AlertSeverity.HIGH)
+        assert len(high_alerts) == 1
+
+    def test_get_alert_history(self):
+        manager = AlertManager(include_default_rules=False)
+        manager._alert_history.append(Alert(severity=AlertSeverity.HIGH, rule_name="a"))
+        manager._alert_history.append(Alert(severity=AlertSeverity.LOW, rule_name="b"))
+        history = manager.get_alert_history(severity=AlertSeverity.HIGH)
+        assert len(history) == 1
+        assert history[0]["rule_name"] == "a"
+
+    def test_export_import_rules(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(name="r1", metric_path="global.error_rate", threshold=0.1))
+        manager.add_rule(AlertRule(name="r2", metric_path="global.avg_latency_ms", threshold=5000))
+
+        exported = manager.export_rules()
+        assert len(exported) == 2
+
+        manager2 = AlertManager(include_default_rules=False)
+        count = manager2.import_rules(exported)
+        assert count == 2
+        assert len(manager2.list_rules()) == 2
+
+    def test_reset(self):
+        manager = AlertManager(include_default_rules=False)
+        manager._stats["total_evaluations"] = 10
+        manager._alert_history.append(Alert())
+        manager.reset()
+        assert manager._stats["total_evaluations"] == 0
+        assert len(manager._alert_history) == 0
+
+    def test_get_stats(self):
+        manager = AlertManager(include_default_rules=False)
+        manager.add_rule(AlertRule(name="r1"))
+        stats = manager.get_stats()
+        assert stats["rule_count"] == 1
+        assert stats["enabled_rules"] == 1
+        assert stats["firing_alerts"] == 0
+        assert "notifier_stats" in stats
+
+
+# ── Default Alert Rules Tests ──────────────────────────────
+
+
+class TestDefaultAlertRules:
+    """Tests for default alert rules."""
+
+    def test_default_rules_count(self):
+        from cn_commerce_base import DEFAULT_ALERT_RULES
+        assert len(DEFAULT_ALERT_RULES) == 4
+
+    def test_default_high_error_rate(self):
+        from cn_commerce_base import DEFAULT_ALERT_RULES
+        rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "high_error_rate")
+        assert rule.threshold == 0.1
+        assert rule.severity == AlertSeverity.HIGH
+        assert rule.comparison == "gt"
+
+    def test_default_critical_error_rate(self):
+        from cn_commerce_base import DEFAULT_ALERT_RULES
+        rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "critical_error_rate")
+        assert rule.threshold == 0.5
+        assert rule.severity == AlertSeverity.CRITICAL
+
+    def test_default_high_latency(self):
+        from cn_commerce_base import DEFAULT_ALERT_RULES
+        rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "high_latency")
+        assert rule.threshold == 5000.0
+        assert rule.severity == AlertSeverity.MEDIUM
+
+    def test_default_critical_latency(self):
+        from cn_commerce_base import DEFAULT_ALERT_RULES
+        rule = next(r for r in DEFAULT_ALERT_RULES if r.name == "critical_latency")
+        assert rule.threshold == 30000.0
+        assert rule.severity == AlertSeverity.HIGH
+
+
+# ── CommerceMCPBase Alerting Integration Tests ─────────────
+
+
+class TestCommerceMCPBaseAlerting:
+    """Tests for alerting integration in CommerceMCPBase."""
+
+    def test_has_alert_manager(self):
+        client = CommerceMCPBase()
+        assert isinstance(client.alert_manager, AlertManager)
+
+    def test_evaluate_alerts(self):
+        client = CommerceMCPBase()
+        # Add a rule that will trigger
+        client.alert_manager.add_rule(AlertRule(
+            name="test",
+            metric_path="global.total_requests",
+            threshold=0,
+            comparison="gt",
+            cooldown_seconds=0,
+        ))
+        # Record a request so there's a metric
+        client.metrics.record_request("/api/test", latency_ms=100.0, success=True)
+        alerts = client.evaluate_alerts()
+        assert len(alerts) >= 1
+
+    def test_evaluate_alerts_no_trigger(self):
+        client = CommerceMCPBase(app_key="k", app_secret="s")
+        # Default rules: error_rate > 0.1 won't fire when there are no errors
+        client.metrics.record_request("/api/test", latency_ms=10.0, success=True)
+        alerts = client.evaluate_alerts()
+        # Should not trigger high_error_rate (error_rate=0 < 0.1)
+        error_alerts = [a for a in alerts if a.rule_name == "high_error_rate"]
+        assert len(error_alerts) == 0
+
+    @pytest.mark.asyncio
+    async def test_check_and_fire_alerts(self):
+        client = CommerceMCPBase()
+        received = []
+
+        def on_alert(alert):
+            received.append(alert)
+
+        client.alert_manager.notifier.add_callback(on_alert)
+        client.alert_manager.add_rule(AlertRule(
+            name="always_fire",
+            metric_path="global.total_requests",
+            threshold=-1,
+            comparison="gt",
+            cooldown_seconds=0,
+        ))
+        client.metrics.record_request("/api/test", latency_ms=10.0, success=True)
+        results = await client.check_and_fire_alerts()
+        assert len(results) >= 1
+
+    def test_get_alert_stats(self):
+        client = CommerceMCPBase()
+        stats = client.get_alert_stats()
+        assert "rule_count" in stats
+        assert "enabled_rules" in stats
+        assert "notifier_stats" in stats


### PR DESCRIPTION
## Summary

Add a comprehensive monitoring and alerting system to the shared base module, enabling configurable alert rules, threshold evaluation, and notification delivery.

## Changes

### `shared/cn_commerce_base.py`
- **AlertSeverity**: Enum with 4 severity levels (critical/high/medium/low)
- **AlertRule**: Configurable rule dataclass with metric path, threshold, comparison operator, severity, cooldown, platform/endpoint filters
- **Alert**: Fired alert instance with metadata (metric value, threshold, timestamps, status)
- **AlertNotifier**: Notification delivery manager supporting sync/async callbacks
- **AlertManager**: Central manager for rule CRUD, metric evaluation, alert firing/resolution, history tracking, and rule export/import
- **4 default alert rules**: high_error_rate (>10%), critical_error_rate (>50%), high_latency (>5000ms), critical_latency (>30000ms)
- **CommerceMCPBase integration**: `alert_manager` property, `evaluate_alerts()`, `check_and_fire_alerts()`, `get_alert_stats()`

### `docs/monitoring.md`
- Expanded from basic monitoring docs to comprehensive guide covering metrics, health checks, and alerting
- Documented all new classes, fields, default rules, metric paths, and integration patterns

### `tests/test_cn_commerce_base.py`
- 60+ new tests covering AlertSeverity, AlertRule, Alert, AlertNotifier, AlertManager, default rules, and CommerceMCPBase integration
- Tests include rule evaluation, cooldown behavior, platform filtering, notification delivery (sync/async), error handling, export/import, and reset

## Testing
- All 835 tests pass (835 passed in 3.82s)
- No existing functionality broken

## Design Decisions
- Cooldown-based deduplication prevents alert storms
- Rules support both platform and endpoint filtering for targeted alerting
- Notifier supports both sync and async callbacks for flexibility
- Default rules are opt-out (can be disabled via `include_default_rules=False`)
- Export/import enables rule backup and cross-instance sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)