### PR TITLE
docs: sync README tool counts (112→147) and document operational tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ mcp-cn-commerce/
 ├── shared/                           # Shared auth/signing/pagination
 │   └── cn_commerce_base.py           # CommerceMCPBase — extend for new platforms
 ├── servers/
-│   ├── oceanengine/  17 tools        ├── doudian/    20 tools
-│   ├── jd/           14 tools        ├── taobao/     13 tools
-│   ├── pinduoduo/    13 tools        ├── kuaishou/   12 tools
-│   ├── xiaohongshu/  12 tools        └── weixin-store/ 11 tools
+│   ├── oceanengine/  22 tools        ├── doudian/    24 tools
+│   ├── jd/           19 tools        ├── taobao/     17 tools
+│   ├── pinduoduo/    17 tools        ├── kuaishou/   16 tools
+│   ├── xiaohongshu/  17 tools        └── weixin-store/ 15 tools
 ├── docs/platforms.md                 # 8-platform API comparison & auth matrix
 ├── docs/docker.md                    # Docker deployment guide
 ├── Dockerfile                        # Multi-platform MCP server image
@@ -197,15 +197,20 @@ Each `servers/<platform>/` is an **independent MCP server**. Users install only 
 
 | Server | Tools | Categories |
 |---|---|---|
-| oceanengine | 17 | Ads, Qianchuan, Star, Creative, Audience, Optimization |
-| doudian | 20 | Orders, Products, Refunds, Logistics, Reviews, Live, Traffic, Marketing, Billing, Shop |
-| jd | 14 | Orders, Products, After-Sale, Logistics, Reviews, Pricing, Inventory, Marketing, Shop |
-| taobao | 13 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing, Categories |
-| pinduoduo | 13 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing, Affiliate |
-| kuaishou | 12 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing |
-| xiaohongshu | 12 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing, Inventory, Finance |
-| weixin-store | 11 | Orders, Products, Refunds, Logistics, Shop, Marketing, Supply Chain, Categories |
-| **Total** | **112** | All read-only by default |
+| oceanengine | 22 | Ads, Qianchuan, Star, Creative, Audience, Optimization |
+| doudian | 24 | Orders, Products, Refunds, Logistics, Reviews, Live, Traffic, Marketing, Billing, Shop |
+| jd | 19 | Orders, Products, After-Sale, Logistics, Reviews, Pricing, Inventory, Marketing, Shop |
+| taobao | 17 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing, Categories |
+| pinduoduo | 17 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing, Affiliate |
+| kuaishou | 16 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing |
+| xiaohongshu | 17 | Orders, Products, Refunds, Logistics, Reviews, Shop, Marketing, Inventory, Finance |
+| weixin-store | 15 | Orders, Products, Refunds, Logistics, Shop, Marketing, Supply Chain, Categories |
+| **Total** | **147** | Platform tools + 4 shared operational tools each |
+
+Every server also exposes **4 cross-platform operational tools** (counted above): `get_metrics`
+(per-endpoint latency / success / error stats), `get_traces` (recent request traces),
+`get_alerts` (alert-rule evaluation against live metrics), and `export_data` (export records
+to CSV/JSON). Request tracing and metrics are collected automatically on every call.
 
 For full tool details, see the source code in each `servers/<platform>/src/` directory.
 | `get_product_list` | Product catalog with pricing and stock | `/product/list` |
@@ -217,7 +222,7 @@ This project handles sensitive e-commerce API credentials. Our security guarante
 
 - 🔒 **Runs locally** — API keys and secrets never leave your machine
 - 📖 **Open source** — every line of code is auditable
-- 👁️ **Read-only by default** — all 112 tools only read data; zero write/modify/delete operations
+- 👁️ **Read-only by default** — all platform tools only read data; zero write/modify/delete operations
 - 📡 **No telemetry** — no usage data is collected, tracked, or transmitted
 - 🖥️ **Direct API calls** — connects directly to platform APIs; no intermediate server or proxy
 - 🔑 **Env-var config** — credentials are loaded from environment variables, never hardcoded

--- a/README_zh.md
+++ b/README_zh.md
@@ -165,15 +165,19 @@ export JD_ACCESS_TOKEN="你的 Access Token"
 
 | Server | 工具数 | 覆盖类别 |
 |---|---|---|
-| oceanengine | 17 | 广告、千川、星图、素材、人群、优化 |
-| doudian | 20 | 订单、商品、售后、物流、评价、直播、流量、营销、资金、店铺 |
-| jd | 14 | 订单、商品、售后、物流、评价、价格、库存、营销、店铺 |
-| taobao | 13 | 订单、商品、售后、物流、评价、店铺、营销、类目 |
-| pinduoduo | 13 | 订单、商品、售后、物流、评价、店铺、营销、多多客 |
-| kuaishou | 12 | 订单、商品、售后、物流、评价、店铺、营销 |
-| xiaohongshu | 12 | 订单、商品、售后、物流、评价、店铺、营销、库存、财务 |
-| weixin-store | 11 | 订单、商品、售后、物流、店铺、营销、供货、类目 |
-| **合计** | **112** | 全部默认只读 |
+| oceanengine | 22 | 广告、千川、星图、素材、人群、优化 |
+| doudian | 24 | 订单、商品、售后、物流、评价、直播、流量、营销、资金、店铺 |
+| jd | 19 | 订单、商品、售后、物流、评价、价格、库存、营销、店铺 |
+| taobao | 17 | 订单、商品、售后、物流、评价、店铺、营销、类目 |
+| pinduoduo | 17 | 订单、商品、售后、物流、评价、店铺、营销、多多客 |
+| kuaishou | 16 | 订单、商品、售后、物流、评价、店铺、营销 |
+| xiaohongshu | 17 | 订单、商品、售后、物流、评价、店铺、营销、库存、财务 |
+| weixin-store | 15 | 订单、商品、售后、物流、店铺、营销、供货、类目 |
+| **合计** | **147** | 平台工具 + 每个 server 额外 4 个通用运维工具 |
+
+每个 server 还额外暴露 **4 个跨平台运维工具**（已计入上表）：`get_metrics`（各接口延迟/成功/错误统计）、
+`get_traces`（最近请求链路）、`get_alerts`（按实时指标评估告警规则）、`export_data`（导出记录为 CSV/JSON）。
+请求链路追踪与指标在每次调用时自动采集。
 
 每个工具的具体用法见各 `servers/<平台>/src/` 目录下的源码。
 
@@ -185,10 +189,10 @@ mcp-cn-commerce/
 ├── shared/                           # 共享基类：签名/请求/分页
 │   └── cn_commerce_base.py           # 继承此基类即可新建平台
 ├── servers/
-│   ├── oceanengine/  17 tools        ├── doudian/    20 tools
-│   ├── jd/           14 tools        ├── taobao/     13 tools
-│   ├── pinduoduo/    13 tools        ├── kuaishou/   12 tools
-│   ├── xiaohongshu/  12 tools        └── weixin-store/ 11 tools
+│   ├── oceanengine/  22 tools        ├── doudian/    24 tools
+│   ├── jd/           19 tools        ├── taobao/     17 tools
+│   ├── pinduoduo/    17 tools        ├── kuaishou/   16 tools
+│   ├── xiaohongshu/  17 tools        └── weixin-store/ 15 tools
 ├── docs/platforms.md                 # 8 平台 API 对比 & 认证方式矩阵
 ├── README.md / README_zh.md          # 英文 / 简体中文
 └── LICENSE                           # MIT
@@ -202,7 +206,7 @@ Monorepo 架构：每个平台是一个独立的 MCP Server，用户按需安装
 
 - 🔒 **本地运行** — API 密钥和凭证存在你的电脑上，不经过任何服务器
 - 📖 **代码开源** — 每一行代码都可审计
-- 👁️ **默认只读** — 全部 112 个工具只读数据，零写入/修改/删除操作
+- 👁️ **默认只读** — 全部平台工具只读数据，零写入/修改/删除操作
 - 📡 **无数据收集** — 不收集、不追踪、不上传任何使用数据
 - 🖥️ **直连平台 API** — 代码直接调用平台 API，无中间服务器或代理
 - 🔑 **环境变量配置** — 凭证通过环境变量加载，绝不硬编码


### PR DESCRIPTION
跟进 #61：Item 3 给每个 server 都加了 4 个跨平台运维工具（`get_metrics`/`get_traces`/`get_alerts`/`export_data`），但顶层 README 的工具数没同步。本 PR 纯文档。

## 改动（仅 README.md / README_zh.md）
- 工具数表 + 目录树更新为实际值（经 `list_tools()` 实测）：

  | server | 旧 | 新 | | server | 旧 | 新 |
  |---|---|---|---|---|---|---|
  | doudian | 20 | 24 | | jd | 14 | 19 |
  | oceanengine | 17 | 22 | | taobao | 13 | 17 |
  | pinduoduo | 13 | 17 | | xiaohongshu | 12 | 17 |
  | kuaishou | 12 | 16 | | weixin-store | 11 | 15 |
  | **合计** | **112** | **147** | | | | |

- 新增一小节说明：tracing/metrics 每次请求自动采集，4 个通用运维工具的用途。
- 安全条目里写死的 "112 tools" 改为"全部平台工具"。

无代码改动，不影响 CI 逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)