### PR TITLE
fix: oceanengine/doudian servers crashed on startup against the real MCP SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to mcp-cn-commerce will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.3] - 2026-06-10
+
+### Fixed
+
+- **修复 oceanengine / doudian 两个 server 无法启动的问题**：二者使用底层
+  `mcp.server.Server` 却调用只有 FastMCP 才有的 `@server.tool()`，在真实
+  MCP SDK 下导入即抛 `AttributeError`（`mcp-cn-oceanengine` / `mcp-cn-doudian`
+  命令此前从未真正可用）。现已迁移到 FastMCP，与其余 6 个平台一致。
+- 移除测试中掩盖该问题的 `Server.tool` monkey-patch 兼容垫片；
+  `tests/test_common_tools.py` 统一按 FastMCP 路径校验全部 8 个 server。
+
 ## [0.1.2] - 2026-06-10
 
 ### Fixed

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/TonyWang-hub/mcp-cn-commerce",
     "source": "github"
   },
-  "version": "0.1.2",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-cn-commerce",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       },

--- a/servers/doudian/server.py
+++ b/servers/doudian/server.py
@@ -22,8 +22,7 @@ import os
 import time
 from typing import Any
 
-from mcp.server import Server
-from mcp.server.stdio import stdio_server
+from mcp.server.fastmcp import FastMCP
 
 from shared.cn_commerce_base import (
     CommerceAPIError,
@@ -36,7 +35,7 @@ from shared.cn_commerce_base import (
 
 logger = logging.getLogger(__name__)
 
-server = Server("mcp-cn-doudian")
+server = FastMCP("mcp-cn-doudian")
 
 # ── Exceptions ──────────────────────────────────────────────
 
@@ -1695,17 +1694,7 @@ register_common_tools(server, _get_client)
 
 def main() -> None:
     """Run the Doudian MCP server via stdio transport."""
-    import asyncio
-
-    async def _run() -> None:
-        async with stdio_server() as (read_stream, write_stream):
-            await server.run(
-                read_stream,
-                write_stream,
-                server.create_initialization_options(),
-            )
-
-    asyncio.run(_run())
+    server.run()
 
 
 if __name__ == "__main__":

--- a/servers/doudian/tests/test_doudian.py
+++ b/servers/doudian/tests/test_doudian.py
@@ -6,31 +6,8 @@ import os
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-# ═════════════════════════════════════════════════════════════════════
-#  Compatibility shim — MCP >=1.27 moved the tool() decorator to
-#  FastMCP.  The server under test was written for an older MCP API
-#  where Server had a .tool() method.  Monkey-patch it so the module
-#  can be imported and the decorator is a transparent pass-through.
-# ═════════════════════════════════════════════════════════════════════
-import mcp.server  # noqa: E402
 import pytest
 
-_orig_server_cls = mcp.server.Server
-
-if not hasattr(_orig_server_cls, "tool"):
-
-    def _mock_tool(self, *args: Any, **kwargs: Any) -> Any:
-        """Pass-through decorator — returns the function unchanged."""
-
-        def decorator(func: Any) -> Any:
-            return func
-
-        return decorator
-
-    _orig_server_cls.tool = _mock_tool  # type: ignore[attr-defined]
-
-
-# Now safe to import the module under test.
 import servers.doudian.server as _srv  # noqa: E402 — the module itself (for patching)
 from servers.doudian.server import (  # noqa: E402
     ConfigError,

--- a/servers/oceanengine/server.py
+++ b/servers/oceanengine/server.py
@@ -6,12 +6,10 @@ Uses OAuth 2.0 for authentication via open.oceanengine.com.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 
-from mcp.server import Server
-from mcp.server.stdio import stdio_server
+from mcp.server.fastmcp import FastMCP
 
 from shared.cn_commerce_base import (
     CommerceMCPBase,
@@ -46,7 +44,7 @@ def _get_client() -> OceanEngine:
 # ── MCP Server ───────────────────────────────────────────
 
 
-server = Server("mcp-cn-oceanengine")
+server = FastMCP("mcp-cn-oceanengine")
 
 
 # ── Helpers ──────────────────────────────────────────────
@@ -593,12 +591,7 @@ register_common_tools(server, _get_client)
 
 def main() -> None:
     """Entry point: run the MCP server over stdio."""
-
-    async def _run() -> None:
-        async with stdio_server() as (read, write):
-            await server.run(read, write)
-
-    asyncio.run(_run())
+    server.run()
 
 
 if __name__ == "__main__":

--- a/servers/oceanengine/tests/test_oceanengine.py
+++ b/servers/oceanengine/tests/test_oceanengine.py
@@ -15,25 +15,6 @@ import pytest
 # Repo root, used by tests that probe the on-disk project layout (e.g. .env).
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
-# ── Compatibility shim: MCP >=1.27 moved the tool() decorator to ──
-# FastMCP. The server under test uses @server.tool().  Monkey-patch
-# Server so the module can be imported under newer MCP versions.
-import mcp.server
-
-_orig_server_cls = mcp.server.Server
-
-if not hasattr(_orig_server_cls, "tool"):
-
-    def _mock_tool(self, *args, **kwargs):
-        """Pass-through decorator — returns the function unchanged."""
-
-        def decorator(func):
-            return func
-
-        return decorator
-
-    _orig_server_cls.tool = _mock_tool  # type: ignore[attr-defined]
-
 from shared.cn_commerce_base import CommerceAPIError  # noqa: E402
 
 # ── Fixtures ────────────────────────────────────────────────

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -6,4 +6,4 @@ every platform server. Public entry points live in :mod:`shared.cn_commerce_base
 
 from __future__ import annotations
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/tests/test_common_tools.py
+++ b/tests/test_common_tools.py
@@ -5,17 +5,9 @@ Item 3B verifies that ``register_common_tools`` (defined in
 servers, exposing the four operational tools ``get_metrics``, ``get_traces``,
 ``get_alerts`` and ``export_data`` on each one.
 
-Two server families exist:
-
-* **FastMCP servers** (jd, kuaishou, pinduoduo, taobao, weixin_store,
-  xiaohongshu) expose a ``mcp = FastMCP(...)`` instance whose registered tools
-  are introspectable via ``await mcp.list_tools()``.
-* **Low-level ``Server`` servers** (doudian, oceanengine) use ``@server.tool()``.
-  Newer MCP releases moved ``tool()`` off ``Server`` onto FastMCP, so — exactly
-  like the existing per-server test suites — we monkey-patch a pass-through
-  ``Server.tool`` before import. Here the shim additionally *records* the names
-  of every function it decorates, letting us assert the four common tools were
-  registered.
+All eight servers expose a FastMCP instance (named ``mcp`` on six of them,
+``server`` on doudian/oceanengine) whose registered tools are introspectable
+via ``await <instance>.list_tools()``.
 """
 
 from __future__ import annotations
@@ -61,30 +53,7 @@ for _k, _v in _ENV.items():
     os.environ.setdefault(_k, _v)
 
 
-# ── Compatibility shim for the low-level ``Server`` servers ──────────────────
-# Record decorated tool names so we can assert what was registered. The real
-# FastMCP servers don't need this; only doudian/oceanengine use Server.tool().
-
-import mcp.server  # noqa: E402
-
-_REGISTERED_TOOLS: list[str] = []
-_orig_server_cls = mcp.server.Server
-
-if not hasattr(_orig_server_cls, "tool"):
-
-    def _recording_tool(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
-        """Pass-through ``.tool()`` decorator that records the function name."""
-
-        def decorator(func):  # noqa: ANN001
-            _REGISTERED_TOOLS.append(func.__name__)
-            return func
-
-        return decorator
-
-    _orig_server_cls.tool = _recording_tool  # type: ignore[attr-defined]
-
-
-# ── Import every server module (after env + shim are in place) ───────────────
+# ── Import every server module (after env is in place) ───────────────────────
 
 import servers.doudian.server as doudian_server  # noqa: E402
 import servers.jd.server as jd_server  # noqa: E402
@@ -98,7 +67,8 @@ from shared.cn_commerce_base import CommerceMCPBase  # noqa: E402
 
 COMMON_TOOLS = {"get_metrics", "get_traces", "get_alerts", "export_data"}
 
-# FastMCP servers: (module, attr name of the FastMCP instance).
+# All servers expose a FastMCP instance; the attribute is ``mcp`` on six of
+# them and ``server`` on doudian/oceanengine.
 FASTMCP_SERVERS = [
     pytest.param(jd_server, id="jd"),
     pytest.param(kuaishou_server, id="kuaishou"),
@@ -106,13 +76,14 @@ FASTMCP_SERVERS = [
     pytest.param(taobao_server, id="taobao"),
     pytest.param(weixin_store_server, id="weixin_store"),
     pytest.param(xiaohongshu_server, id="xiaohongshu"),
-]
-
-# Low-level Server servers.
-LOWLEVEL_SERVERS = [
     pytest.param(doudian_server, id="doudian"),
     pytest.param(oceanengine_server, id="oceanengine"),
 ]
+
+
+def _fastmcp(module):
+    """Return the module's FastMCP instance regardless of its attribute name."""
+    return getattr(module, "mcp", None) or module.server
 
 
 # ── FastMCP servers: introspect via list_tools() ────────────────────────────
@@ -122,7 +93,7 @@ LOWLEVEL_SERVERS = [
 @pytest.mark.parametrize("module", FASTMCP_SERVERS)
 async def test_fastmcp_server_registers_common_tools(module):
     """Each FastMCP server exposes all four common operational tools."""
-    tools = await module.mcp.list_tools()
+    tools = await _fastmcp(module).list_tools()
     names = {t.name for t in tools}
     missing = COMMON_TOOLS - names
     assert not missing, f"{module.__name__} missing common tools: {sorted(missing)}"
@@ -131,43 +102,9 @@ async def test_fastmcp_server_registers_common_tools(module):
 @pytest.mark.parametrize("module", FASTMCP_SERVERS)
 def test_fastmcp_server_keeps_platform_tools(module):
     """Wiring common tools must not drop a server's existing platform tools."""
-    registered = set(module.mcp._tool_manager._tools.keys())
+    registered = set(_fastmcp(module)._tool_manager._tools.keys())
     # Every server has more than just the four common tools.
     assert len(registered - COMMON_TOOLS) > 0
-
-
-# ── Low-level Server servers: introspect via the recording shim ──────────────
-
-
-@pytest.mark.parametrize("module", LOWLEVEL_SERVERS)
-def test_lowlevel_server_registers_common_tools(module):
-    """doudian / oceanengine register the four common tools via @server.tool()."""
-    # The module is likely already imported (e.g. by test_integration), so its
-    # registration won't re-run on a plain import, and another module may have
-    # installed its own Server.tool shim. Install our own recording shim
-    # unconditionally, reload to re-run registration, then restore.
-    import importlib
-
-    import mcp.server
-
-    captured: list[str] = []
-
-    def _recording_tool(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
-        def decorator(func):  # noqa: ANN001
-            captured.append(func.__name__)
-            return func
-
-        return decorator
-
-    original = mcp.server.Server.tool
-    mcp.server.Server.tool = _recording_tool  # type: ignore[attr-defined]
-    try:
-        importlib.reload(module)
-    finally:
-        mcp.server.Server.tool = original  # type: ignore[attr-defined]
-
-    missing = COMMON_TOOLS - set(captured)
-    assert not missing, f"{module.__name__} common tools not registered: {sorted(missing)}"
 
 
 # ── End-to-end: invoke the registered FastMCP tools against a real client ────


### PR DESCRIPTION
## Summary

`mcp-cn-oceanengine` and `mcp-cn-doudian` have never worked in any released version: both modules use the low-level `mcp.server.Server` but register tools with `@server.tool()`, which only exists on FastMCP. Importing either module against the real MCP SDK raises:

```
AttributeError: 'Server' object has no attribute 'tool'
```

The per-server test suites masked this with a monkey-patched pass-through `Server.tool` shim (the shim comment even acknowledges the API mismatch). Discovered while smoke-testing the freshly published 0.1.2 wheel in a clean venv.

## Changes

- Migrate `servers/oceanengine` and `servers/doudian` to `FastMCP` — identical pattern to the other six servers; `main()` now calls `server.run()`
- Remove the `Server.tool` monkey-patch shims from both per-server test suites
- `tests/test_common_tools.py`: drop the low-level recording-shim test; all 8 servers now verified through `list_tools()` on their FastMCP instance
- Bump version to 0.1.3 (PyPI 0.1.2 ships the broken modules); CHANGELOG + server.json updated

## Test plan

- [x] Clean venv with real `mcp==1.27.2`: both modules import, `list_tools()` reports 22 (oceanengine) / 24 (doudian) tools — matches README
- [x] `pytest servers/` — 358 passed; `pytest tests/` — 1092 passed
- [x] ruff + black clean
- [ ] After merge: tag v0.1.3 → release to PyPI → clean-venv verify all 9 entry points

🤖 Generated with [Claude Code](https://claude.com/claude-code)