### PR TITLE
chore: fix MCP registry namespace casing; bump 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to mcp-cn-commerce will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.4] - 2026-06-10
+
+### Fixed
+
+- MCP Registry 归属标记大小写修正：`mcp-name: io.github.TonyWang-hub/mcp-cn-commerce`
+  （Registry 按 GitHub 用户名原始大小写做精确匹配）；server.json 命名空间同步修正。
+
 ## [0.1.3] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -345,4 +345,4 @@ mcp-cn-commerce/
 MIT — 详见 [LICENSE](LICENSE)。
 
 <!-- MCP Registry ownership marker, do not remove -->
-mcp-name: io.github.tonywang-hub/mcp-cn-commerce
+mcp-name: io.github.TonyWang-hub/mcp-cn-commerce

--- a/server.json
+++ b/server.json
@@ -1,18 +1,18 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
-  "name": "io.github.tonywang-hub/mcp-cn-commerce",
+  "name": "io.github.TonyWang-hub/mcp-cn-commerce",
   "description": "Read-only merchant data from 8 Chinese e-commerce platforms: orders, products, after-sales, ads",
   "repository": {
     "url": "https://github.com/TonyWang-hub/mcp-cn-commerce",
     "source": "github"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-cn-commerce",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "transport": {
         "type": "stdio"
       },

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -6,4 +6,4 @@ every platform server. Public entry points live in :mod:`shared.cn_commerce_base
 
 from __future__ import annotations
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
Registry rejected publish twice:
1. permission namespace is `io.github.TonyWang-hub/*` (GitHub login casing) but server.json used lowercase
2. PyPI ownership validation matches the `mcp-name:` README marker case-exactly, so the marker on PyPI needs re-publishing

Fixes both, bumps to 0.1.4 so the corrected marker lands on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)