### PR TITLE
ci: publish to MCP Registry via GitHub Actions OIDC

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -1,0 +1,37 @@
+name: Publish to MCP Registry
+
+# Publishes server.json to registry.modelcontextprotocol.io using GitHub
+# Actions OIDC — no interactive device-flow login needed. The OIDC identity
+# (repository owner) grants publish rights for io.github.TonyWang-hub/*.
+#
+# Run manually (workflow_dispatch) or automatically after a GitHub Release
+# is published. Make sure server.json's versions match the released version
+# BEFORE triggering.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish-registry:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).tar.gz" | tar xz mcp-publisher
+          sudo mv mcp-publisher /usr/local/bin/
+
+      - name: Validate server.json
+        run: mcp-publisher validate
+
+      - name: Login via GitHub OIDC
+        run: mcp-publisher login github-oidc
+
+      - name: Publish
+        run: mcp-publisher publish


### PR DESCRIPTION
Device-flow JWTs expire within minutes, which kept failing the manual registry publish. GitHub Actions OIDC authenticates as the repo owner (`io.github.TonyWang-hub/*`) with no interaction, and future releases auto-publish to the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)