### PR TITLE
ci: fix mcp-publisher release asset name

### DIFF
--- a/.github/workflows/mcp-registry.yml
+++ b/.github/workflows/mcp-registry.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install mcp-publisher
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m).tar.gz" | tar xz mcp-publisher
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
           sudo mv mcp-publisher /usr/local/bin/
 
       - name: Validate server.json


### PR DESCRIPTION
Release assets are named `mcp-publisher_linux_amd64.tar.gz`; `uname -m` yields `x86_64`, so the download 404'd (and `curl -L` without `-f` piped the error body into tar). Hardcode the runner arch and add `-f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)