### PR TITLE
chore: add glama.json (Glama directory ownership claim)

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["TonyWang-hub"]
+}


### PR DESCRIPTION
Required by punkpeye/awesome-mcp-servers#7740 review: claim the server on Glama. `glama.json` with the maintainers field is Glama's documented repo-side claim mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)