### PR TITLE
test: defuse secret-scanner false positive (mock WeChat shop_id)

### DIFF
--- a/servers/weixin_store/tests/test_weixin_store.py
+++ b/servers/weixin_store/tests/test_weixin_store.py
@@ -319,7 +319,7 @@ def shop_info_payload() -> dict:
         "errcode": 0,
         "errmsg": "ok",
         "shop_info": {
-            "shop_id": "wx1234567890abcdef",
+            "shop_id": "test_shop_id_001",
             "shop_name": "数码旗舰店",
             "shop_type": 1,
             "shop_logo": "https://wximg.com/logo.png",
@@ -732,7 +732,7 @@ async def test_get_shop_info_returns_shop_details(mock_request, shop_info_payloa
 
     assert result["errcode"] == 0
     shop = result["shop_info"]
-    assert shop["shop_id"] == "wx1234567890abcdef"
+    assert shop["shop_id"] == "test_shop_id_001"
     assert shop["shop_name"] == "数码旗舰店"
     assert shop["shop_type"] == 1
     assert "shop_logo" in shop


### PR DESCRIPTION
GitHub secret scanning alert #1 flagged `wx1234567890abcdef` in `test_weixin_store.py` as a Tencent WeChat App ID. It's an obviously synthetic mock fixture (sequential hex), not a real credential — but renaming it to `test_shop_id_001` stops it matching the detector pattern so the alert never recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)