### PR TITLE
chore: pre-push 钩子——阻止公司邮箱进入 GitHub

### DIFF
--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# pre-push hook — 阻止公司邮箱（dmall.com）被推送到任何远端。
+#
+# 检查两处：① 待推送 commit 的 author/committer 邮箱；② 待推送 tip 树里文件内容。
+# 命中任一即中止推送，退出码非 0。
+#
+# 安装（每次 clone 后执行一次，git 钩子不随仓库自动生效）：
+#   cp scripts/git-hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+# 或：  ln -sf ../../scripts/git-hooks/pre-push .git/hooks/pre-push
+#
+# 临时绕过（仅在确认无泄露时）：  git push --no-verify
+
+set -u
+
+# 要拦截的模式（公司域名；大小写不敏感）
+PATTERN='dmall\.com'
+
+zero_oid() { [[ "$1" =~ ^0+$ ]]; }
+
+blocked=0
+
+while read -r local_ref local_oid remote_ref remote_oid; do
+    # 删除分支：local_oid 全 0，跳过
+    zero_oid "$local_oid" && continue
+
+    if zero_oid "$remote_oid"; then
+        # 新分支：取本地有、所有 origin 远端都没有的 commit
+        range=$(git rev-list "$local_oid" --not --remotes=origin)
+    else
+        range=$(git rev-list "${remote_oid}..${local_oid}")
+    fi
+
+    # ① 身份检查（author + committer 邮箱）
+    if [ -n "$range" ]; then
+        bad_id=$(git show -s --format='%H %ae %ce' $range 2>/dev/null | grep -iE "$PATTERN" || true)
+        if [ -n "$bad_id" ]; then
+            echo "🚫 pre-push 拦截：以下 commit 的作者/提交者含公司邮箱（${PATTERN}）：" >&2
+            echo "$bad_id" >&2
+            blocked=1
+        fi
+    fi
+
+    # ② 内容检查（待推送 tip 树里的文件；排除本钩子脚本自身，否则会匹配到 PATTERN 字面量）
+    bad_content=$(git grep -I -i -n -e "$PATTERN" "$local_oid" -- . ':(exclude)scripts/git-hooks/*' 2>/dev/null || true)
+    if [ -n "$bad_content" ]; then
+        echo "🚫 pre-push 拦截：以下文件内容含公司邮箱（${PATTERN}）：" >&2
+        echo "$bad_content" | head -20 >&2
+        blocked=1
+    fi
+done
+
+if [ "$blocked" -ne 0 ]; then
+    echo "" >&2
+    echo "推送已中止。请改用个人身份（oneDogge <359867620@qq.com>）并清除公司邮箱后再推。" >&2
+    echo "确需绕过：git push --no-verify" >&2
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
装一个 pre-push 钩子：任何推送只要 commit 的 author/committer 邮箱、或 tip 树文件内容里出现公司域名，就中止推送。

**安装（每次 clone 后一次）**：
\`\`\`
cp scripts/git-hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
\`\`\`
确认无泄露时可绕过：\`git push --no-verify\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)