### PR TITLE
ci: fix stale dependabot config + dead-on-arrival auto-merge approve step

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,30 +10,6 @@ updates:
       - "auto-merge"
     open-pull-requests-limit: 10
 
-  - package-ecosystem: "pip"
-    directory: "/servers/oceanengine"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/servers/doudian"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels:
-      - "dependencies"
-
-  - package-ecosystem: "pip"
-    directory: "/servers/jd"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    labels:
-      - "dependencies"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -26,12 +26,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Approve PR
-        if: >-
-          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to mcp-cn-commerce will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Dependabot 每周对 `/servers/oceanengine`、`/servers/doudian`、`/servers/jd` 三个目录报 update failure：
+  这三个目录自 0.1.1 重构为单一包架构后已不再有独立的 `pyproject.toml`，`dependabot.yml`
+  却仍在扫描它们，导致每周一持续产生失败噪音（实测 2026-06-29、2026-07-06 两次）。移除这三段配置。
+- "Auto-merge Dependabot PRs" workflow 里的 `Approve PR` 步骤持续失败：GitHub 平台层面不允许
+  Actions bot 自我批准 PR（`GitHub Actions is not permitted to approve pull requests`）。
+  该仓库分支保护本就是 `required_approving_review_count: 0`，这一步从一开始就是多余的，直接移除。
+
 ## [0.1.4] - 2026-06-10
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Removed 3 stale `pip` entries in `.github/dependabot.yml` (`/servers/oceanengine`, `/servers/doudian`, `/servers/jd`) — these directories lost their own `pyproject.toml` back in the 0.1.1 single-package refactor, so Dependabot has been failing on them every Monday since (observed failures 2026-06-29, 2026-07-06).
- Removed the `Approve PR` step from `auto-merge.yml` — GitHub Actions bots are not permitted to approve PRs at the platform level, so this step has always failed. Branch protection requires 0 approving reviews, so it was never actually needed.
- Logged both in CHANGELOG under `[Unreleased]`.

## Test plan
- [ ] Confirm next Dependabot run (Monday) no longer reports failures for the removed directories
- [ ] Confirm next dependabot patch/minor PR auto-merges cleanly without the approve step erroring