### PR TITLE
chore: bump version to 0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to mcp-cn-commerce will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.1.5] - 2026-07-13
 
 ### Fixed
 

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/TonyWang-hub/mcp-cn-commerce",
     "source": "github"
   },
-  "version": "0.1.4",
+  "version": "0.1.5",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "mcp-cn-commerce",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "transport": {
         "type": "stdio"
       },

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -6,4 +6,4 @@ every platform server. Public entry points live in :mod:`shared.cn_commerce_base
 
 from __future__ import annotations
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"


### PR DESCRIPTION
## Summary
- Bumps version to 0.1.5 in `shared/__init__.py` and `server.json` (both the top-level and package version fields).
- Finalizes the `[Unreleased]` CHANGELOG section as `[0.1.5] - 2026-07-13` covering the CI fixes from #94.
- Verified full test suite (1092 tests) passes locally before opening this.

## Test plan
- [x] `pytest tests/ -q` — 1092 passed
- [ ] After merge: tag `v0.1.5` and push to trigger Build & Release → PyPI publish → MCP Registry sync